### PR TITLE
🔧 (#55) .swiftlint.yml 수정 : excluded 파일 추가

### DIFF
--- a/MobalMobal/.swiftlint.yml
+++ b/MobalMobal/.swiftlint.yml
@@ -569,3 +569,6 @@ function_body_length:
   
 reporter: "xcode"
 
+excluded:
+  - MobalMobal/Extension/UIColor+Additions.swift
+  - MobalMobal/ViewController.swift


### PR DESCRIPTION
### Related Issue
resolve: #55

### What does this PR do?
- MobalMobal/Extension/UIColor+Additions.swift
- MobalMobal/ViewController.swift
- 두 개의 파일 린트 검사에서 제외

### Why are we doing this?
- **`UIColor+Additions.swift`**
    - Zeplin styleguide에서 뽑아온 파일이고, 모든 branch에서 계속 업데이트 되는 파일
    - merge conflict를 막기 위해 항상 Zeplin에서 주는 최신 상태 그대로 유지되어야 함.
- **`ViewController.swift`**
    - 초기 화면을 이동을 위한 뷰컨트롤러이기 때문에 나중에는 사용하지 않을 예정
    - 린트 규칙이 중요하지 않음.

### Screenshots
<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/987836f9-2b4e-4d7d-b14c-ec7460a92daa/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210307%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210307T055033Z&X-Amz-Expires=86400&X-Amz-Signature=e6c275700752117e980d94e3ac7825c6926fd81864167551ce97d718183ce664&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22" width=600>
