### PR TITLE
(#63) 가로모드 제한

### DIFF
--- a/MobalMobal/MobalMobal/AppDelegate.swift
+++ b/MobalMobal/MobalMobal/AppDelegate.swift
@@ -11,6 +11,8 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    var shoudSupportAllOrientation: Bool = false
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         FirebaseApp.configure()
@@ -30,6 +32,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         return true
     }
+    
+    // screen orientation
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if shoudSupportAllOrientation {
+            return .all
+        }
+        return .portrait
+    }
 
     // MARK: UISceneSession Lifecycle
 
@@ -44,6 +54,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
+    
 }
 
 // MARK: - UNUserNotificationCenterDelegate


### PR DESCRIPTION
### Related Issue

resolve: #63

### What does this PR do?
- 화면 회전을 제한하였습니다. (세로모드 portrait) 고정
- `AppDelegate`의 `shouldSupportAllOrientation`을 true로 하면 화면 회전 사용 가능!

### Why are we doing this?
- 가로모드로 하면 화면 깨지는 UI가 많습니다..
