### PR TITLE
🎨 (#75) 공통으로 들어가는 navigation bar appearance 설정

### DIFF
--- a/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
+++ b/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		3A1BD77125F539D40079D56D /* Spoqa Han Sans Neo Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3A1BD76C25F539D40079D56D /* Spoqa Han Sans Neo Medium.otf */; };
 		3A1BD77C25F5443D0079D56D /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1BD77B25F5443D0079D56D /* UIFont+Extension.swift */; };
 		3A6CFF3325EAEC7A00214E43 /* CustomLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6CFF3225EAEC7A00214E43 /* CustomLoginButton.swift */; };
+		3AB1CFD6260F7CB200EA94E8 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CFD5260F7CB200EA94E8 /* UIViewController+Extension.swift */; };
 		6A7F9880C2DD6C6782A998EE /* Pods_MobalMobal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5C411755E7FEF436016D7E /* Pods_MobalMobal.framework */; };
 		7C04535625EA949B00870761 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C04535525EA949B00870761 /* ProfileViewController.swift */; };
 		7C04535A25EA98B900870761 /* ProfileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C04535925EA98B900870761 /* ProfileTableViewCell.swift */; };
@@ -85,6 +86,7 @@
 		3A1BD76C25F539D40079D56D /* Spoqa Han Sans Neo Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Spoqa Han Sans Neo Medium.otf"; sourceTree = "<group>"; };
 		3A1BD77B25F5443D0079D56D /* UIFont+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		3A6CFF3225EAEC7A00214E43 /* CustomLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLoginButton.swift; sourceTree = "<group>"; };
+		3AB1CFD5260F7CB200EA94E8 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		5A5C411755E7FEF436016D7E /* Pods_MobalMobal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MobalMobal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61483D18A64727D4EAFF1EDD /* Pods-MobalMobal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MobalMobal.debug.xcconfig"; path = "Target Support Files/Pods-MobalMobal/Pods-MobalMobal.debug.xcconfig"; sourceTree = "<group>"; };
 		7C04535525EA949B00870761 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				E3692D1C25F4F9C500755FBF /* UIView+Extension.swift */,
 				3A1BD77B25F5443D0079D56D /* UIFont+Extension.swift */,
 				3A179F7625FBC84F00901436 /* UITextField+Extension.swift */,
+				3AB1CFD5260F7CB200EA94E8 /* UIViewController+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -558,6 +561,7 @@
 				7C39979125F75B5900EA82C2 /* SuccessChargingViewController.swift in Sources */,
 				7C61AEC925EA4CC200D9149F /* PointChargingViewController.swift in Sources */,
 				E3692D1D25F4F9C500755FBF /* UIView+Extension.swift in Sources */,
+				3AB1CFD6260F7CB200EA94E8 /* UIViewController+Extension.swift in Sources */,
 				E3F1EAB225EACC9F00F34BDE /* SignupCustomView.swift in Sources */,
 				7C842FA02606267400A66756 /* ModifyProfileViewController.swift in Sources */,
 				7C04536025EAA2DC00870761 /* ProfileDonatingTableViewCell.swift in Sources */,

--- a/MobalMobal/MobalMobal/Account/AccountViewController.swift
+++ b/MobalMobal/MobalMobal/Account/AccountViewController.swift
@@ -92,8 +92,11 @@ class AccountViewController: UIViewController {
         super.viewDidLoad()
         accountLabelTapGesture()
         self.view.backgroundColor = .backgroundColor
-        self.navigationController?.navigationBar.isHidden = true
         view.setNeedsUpdateConstraints()
+    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     override func updateViewConstraints() {
         self.view.addSubviews([verticalStackView, closeButton])

--- a/MobalMobal/MobalMobal/AppDelegate.swift
+++ b/MobalMobal/MobalMobal/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        setNavigationAppearance()
+        
         FirebaseApp.configure()
         
         // setting Firebase Cloud Messaging
@@ -55,6 +57,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
     
+    private func setNavigationAppearance() {
+        let standard: UINavigationBarAppearance = UINavigationBarAppearance()
+        
+        // background
+        standard.configureWithOpaqueBackground()
+        standard.backgroundColor = .black94
+        
+        // title
+        standard.titleTextAttributes = [
+            .foregroundColor: UIColor.whiteTwo,
+            .font: UIFont.spoqaHanSansNeo(ofSize: 17, weight: .medium)
+        ]
+        
+        // button
+        let btnAppearance: UIBarButtonItemAppearance = UIBarButtonItemAppearance(style: .plain)
+        btnAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.white]
+        standard.buttonAppearance = btnAppearance
+        
+        UINavigationBar.appearance().standardAppearance = standard
+    }
 }
 
 // MARK: - UNUserNotificationCenterDelegate

--- a/MobalMobal/MobalMobal/AppDelegate.swift
+++ b/MobalMobal/MobalMobal/AppDelegate.swift
@@ -75,6 +75,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         btnAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.white]
         standard.buttonAppearance = btnAppearance
         
+        UINavigationBar.appearance().tintColor = .white
         UINavigationBar.appearance().standardAppearance = standard
     }
 }

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
@@ -35,9 +35,13 @@ class DonateMoneyViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .clear
         
-        setNavigation()
         setConstraints()
         setViewTapGesture()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     
     override func viewDidLayoutSubviews() {
@@ -52,9 +56,6 @@ class DonateMoneyViewController: UIViewController {
     }
     
     // MARK: - Methods
-    private func setNavigation() {
-        navigationController?.setNavigationBarHidden(true, animated: true)
-    }
     private func setConstraints() {
         view.addSubviews([tableView, clearView])
         tableView.snp.makeConstraints { make in

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
@@ -35,6 +35,7 @@ class DonateMoneyViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .clear
         
+        setNavigation()
         setConstraints()
         setViewTapGesture()
     }
@@ -51,6 +52,9 @@ class DonateMoneyViewController: UIViewController {
     }
     
     // MARK: - Methods
+    private func setNavigation() {
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
     private func setConstraints() {
         view.addSubviews([tableView, clearView])
         tableView.snp.makeConstraints { make in
@@ -76,7 +80,6 @@ extension DonateMoneyViewController: UITableViewDelegate {
             let inputDonateMoneyVC: InputDonationMoneyViewController = InputDonationMoneyViewController()
             inputDonateMoneyVC.modalPresentationStyle = .fullScreen
             navigationController?.pushViewController(inputDonateMoneyVC, animated: true)
-            navigationController?.setNavigationBarHidden(false, animated: true)
         }
     }
 }

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
@@ -39,11 +39,6 @@ class DonateMoneyViewController: UIViewController {
         setViewTapGesture()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.isNavigationBarHidden = true
-    }
-    
     override func viewDidLayoutSubviews() {
         tableView.roundCorners(corners: [.topLeft, .topRight], radius: 30)
         tableView.drawShadow(color: .black, alpha: 1.0, shadowX: 0, shadowY: 20, blur: 20, spread: 0)

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -242,7 +242,8 @@ class DonationDetailViewController: UIViewController {
         let donateMoneyVC: DonateMoneyViewController = DonateMoneyViewController()
         let navigationController: UINavigationController = UINavigationController(rootViewController: donateMoneyVC)
         navigationController.modalPresentationStyle = .overFullScreen
-        present(navigationController, animated: true, completion: nil)
+        navigationController.setNavigationBarHidden(true, animated: true)
+        present(navigationController, animated: true)
     }
     
     // MARK: - Methods

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -242,7 +242,6 @@ class DonationDetailViewController: UIViewController {
         let donateMoneyVC: DonateMoneyViewController = DonateMoneyViewController()
         let navigationController: UINavigationController = UINavigationController(rootViewController: donateMoneyVC)
         navigationController.modalPresentationStyle = .overFullScreen
-//        navigationController.setNavigationBarHidden(true, animated: true)
         present(navigationController, animated: true)
     }
     

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -242,7 +242,7 @@ class DonationDetailViewController: UIViewController {
         let donateMoneyVC: DonateMoneyViewController = DonateMoneyViewController()
         let navigationController: UINavigationController = UINavigationController(rootViewController: donateMoneyVC)
         navigationController.modalPresentationStyle = .overFullScreen
-        navigationController.setNavigationBarHidden(true, animated: true)
+//        navigationController.setNavigationBarHidden(true, animated: true)
         present(navigationController, animated: true)
     }
     

--- a/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
+++ b/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewController+Extension.swift
+//  MobalMobal
+//
+//  Created by 임수현 on 2021/03/27.
+//
+
+import UIKit
+extension UIViewController {
+ 
+    func setNavigationItems(title: String, backButtonImageName: String, action: Selector?) {
+        self.navigationItem.title = title
+        
+        guard let backButtonImage: UIImage = UIImage(named: backButtonImageName) else { return }
+        let backButton: UIBarButtonItem = UIBarButtonItem(image: backButtonImage, style: .plain, target: self, action: action)
+        navigationItem.leftBarButtonItem = backButton
+    }
+}

--- a/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
+++ b/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 extension UIViewController {
- 
     func setNavigationItems(title: String, backButtonImageName: String, action: Selector?) {
         self.navigationItem.title = title
         

--- a/MobalMobal/MobalMobal/InputChargingPoint/InputChargingPointViewController.swift
+++ b/MobalMobal/MobalMobal/InputChargingPoint/InputChargingPointViewController.swift
@@ -64,12 +64,12 @@ class InputChargingPointViewController: UIViewController {
         self.view.backgroundColor = .backgroundColor
         self.chargingInputField.becomeFirstResponder()
         viewTapGesture()
-        setNavigation()
+        setNavigationItems()
         setLayout()
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.isHidden = false
+        self.navigationController?.setNavigationBarHidden(false, animated: true)
     }
     
     // MARK: - Actions
@@ -130,21 +130,14 @@ class InputChargingPointViewController: UIViewController {
         alertController.addAction(okAction)
         self.present(alertController, animated: true, completion: nil)
     }
-    private func setNavigation() {
-        self.navigationController?.isNavigationBarHidden = false
-        self.navigationController?.navigationBar.isTranslucent = false
-        self.navigationController?.navigationBar.backgroundColor = .black94
-        self.navigationController?.navigationBar.barTintColor = .black94
-        self.navigationItem.title = "충전"
-        self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.white]
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "arrowChevronBigLeft"), style: .plain, target: self, action: #selector(popVC))
-        self.navigationItem.leftBarButtonItem?.tintColor = .white
+    private func setNavigationItems() {
+        self.setNavigationItems(title: "충전", backButtonImageName: "arrowChevronBigLeft", action: #selector(popVC))
     }
     private func setLayout() {
         [chargingButton, chargingInputView].forEach { view.addSubview($0) }
         [chargingViewImage, chargingInputField].forEach { chargingInputView.addSubview($0) }
         chargingInputView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(52)
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(52)
             make.leading.trailing.equalToSuperview().inset(15)
             make.centerX.equalToSuperview()
             make.height.equalTo(60)

--- a/MobalMobal/MobalMobal/InputChargingPoint/InputChargingPointViewController.swift
+++ b/MobalMobal/MobalMobal/InputChargingPoint/InputChargingPointViewController.swift
@@ -69,7 +69,7 @@ class InputChargingPointViewController: UIViewController {
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.setNavigationBarHidden(false, animated: true)
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
     // MARK: - Actions

--- a/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
@@ -65,8 +65,13 @@ class InputDonationMoneyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundColor
+        setNavigationItems()
         setButtonDisable()
-        setNavigation()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
     override func updateViewConstraints() {
@@ -100,8 +105,7 @@ class InputDonationMoneyViewController: UIViewController {
     }
     
     // MARK: - Methods
-    private func setNavigation() {
-        navigationController?.setNavigationBarHidden(false, animated: true)
+    private func setNavigationItems() {
         setNavigationItems(title: navigationTitle, backButtonImageName: backButtonImageName, action: #selector(clickNavigationBackButton))
     }
     

--- a/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
@@ -101,18 +101,8 @@ class InputDonationMoneyViewController: UIViewController {
     
     // MARK: - Methods
     private func setNavigation() {
-        let appearance: UINavigationBarAppearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .black94
-        navigationController?.navigationBar.standardAppearance = appearance
-        
-        appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
-        navigationItem.title = navigationTitle
-        navigationItem.standardAppearance = appearance
-        
-        guard let backButtonImage: UIImage = UIImage(named: backButtonImageName) else { return }
-        let backButton: UIBarButtonItem = UIBarButtonItem(image: backButtonImage, style: .plain, target: self, action: #selector(clickNavigationBackButton))
-        backButton.tintColor = .white
-        navigationItem.leftBarButtonItem = backButton
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        setNavigationItems(title: navigationTitle, backButtonImageName: backButtonImageName, action: #selector(clickNavigationBackButton))
     }
     
     private func setRoundViewConstraints() {

--- a/MobalMobal/MobalMobal/ModifyProfile/ModifyProfileViewController.swift
+++ b/MobalMobal/MobalMobal/ModifyProfile/ModifyProfileViewController.swift
@@ -62,7 +62,11 @@ class ModifyProfileViewController: UIViewController {
         self.view.backgroundColor = .backgroundColor
         setProfileImgGestureRecognizer()
         setDismissKeyboard()
-        setNavigation()
+        setNavigationItems()
+    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: true)
     }
     override func updateViewConstraints() {
         self.view.addSubviews([profileImageView, profileTextFieldStackView, modifyCompleteBtn])
@@ -138,15 +142,8 @@ class ModifyProfileViewController: UIViewController {
         modifyCompleteBtn.backgroundColor = .lightBluishGreen
         modifyCompleteBtn.titleLabel?.textColor = .blackThree
     }
-    private func setNavigation() {
-        self.navigationController?.navigationBar.backgroundColor = .black94
-        self.navigationController?.navigationBar.barTintColor = .black94
-        self.navigationController?.navigationBar.isTranslucent = false
-        self.navigationController?.isNavigationBarHidden = false
-        self.navigationItem.title = "프로필 수정"
-        self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.whiteTwo]
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "arrowChevronBigLeft"), style: .plain, target: self, action: #selector(popVC))
-        self.navigationItem.leftBarButtonItem?.tintColor = .white
+    private func setNavigationItems() {
+        setNavigationItems(title: "프로필 수정", backButtonImageName: "arrowChevronBigLeft", action:  #selector(popVC))
     }
     private func getImgFromLibrary() {
         self.imagePicker.sourceType = .photoLibrary

--- a/MobalMobal/MobalMobal/ModifyProfile/ModifyProfileViewController.swift
+++ b/MobalMobal/MobalMobal/ModifyProfile/ModifyProfileViewController.swift
@@ -66,7 +66,7 @@ class ModifyProfileViewController: UIViewController {
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.setNavigationBarHidden(false, animated: true)
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     override func updateViewConstraints() {
         self.view.addSubviews([profileImageView, profileTextFieldStackView, modifyCompleteBtn])

--- a/MobalMobal/MobalMobal/PointCharging/PointChargingViewController.swift
+++ b/MobalMobal/MobalMobal/PointCharging/PointChargingViewController.swift
@@ -45,12 +45,21 @@ class PointChargingViewController: UIViewController {
         super.viewDidLoad()
         setTableView()
         setViewDismissGesture()
+        setLayout()
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.isHidden = true
+        self.navigationController?.setNavigationBarHidden(true, animated: true)
     }
-    override func updateViewConstraints() {
+    
+    // MARK: - Actions
+    @objc
+    func dismissVC() {
+        self.navigationController?.dismiss(animated: true, completion: nil)
+    }
+    
+    // MARK: - Methods
+    private func setLayout() {
         self.view.addSubviews([transparencyView, contentView])
         self.contentView.addSubviews([chargingTableView, pageTitle])
 
@@ -71,16 +80,7 @@ class PointChargingViewController: UIViewController {
             make.top.leading.trailing.equalToSuperview()
             make.bottom.equalTo(contentView.snp.top)
         }
-        super.updateViewConstraints()
     }
-    
-    // MARK: - Actions
-    @objc
-    func dismissVC() {
-        self.navigationController?.dismiss(animated: true, completion: nil)
-    }
-    
-    // MARK: - Methods
     private func setTableView() {
         self.chargingTableView.delegate = self
         self.chargingTableView.dataSource = self

--- a/MobalMobal/MobalMobal/PointCharging/PointChargingViewController.swift
+++ b/MobalMobal/MobalMobal/PointCharging/PointChargingViewController.swift
@@ -49,7 +49,7 @@ class PointChargingViewController: UIViewController {
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.setNavigationBarHidden(true, animated: true)
+        self.navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     
     // MARK: - Actions

--- a/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
@@ -22,7 +22,10 @@ class ProfileViewController: UIViewController {
     private let donatingCellIdentifier: String = "DonatingTableViewCell"
     private let sectionHeaderCellIdentifier: String = "SectionHeaderCell"
     private let numberOfDonations: [Int] = [1, 1, 1]
+    
     private let modifyVC: UIViewController = ModifyProfileViewController()
+    private let chargingVC: UIViewController = PointChargingViewController()
+    
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,6 +52,11 @@ class ProfileViewController: UIViewController {
     @objc
     private func pushSettingVC() {
         print("✨ push setting vc")
+        
+        // 임시로 PointCharging으로 이동하는 코드
+        let navVC: UINavigationController = UINavigationController(rootViewController: chargingVC)
+        navVC.modalPresentationStyle = .overFullScreen
+        self.present(navVC, animated: true)
     }
     
     // MARK: - Methods

--- a/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
@@ -22,18 +22,24 @@ class ProfileViewController: UIViewController {
     private let donatingCellIdentifier: String = "DonatingTableViewCell"
     private let sectionHeaderCellIdentifier: String = "SectionHeaderCell"
     private let numberOfDonations: [Int] = [1, 1, 1]
+    private let modifyVC: UIViewController = ModifyProfileViewController()
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setTableView()
         setLayout()
-        setNavigation()
+        setNavigationItems()
+    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: true)
     }
     
     // MARK: - Actions
     @objc
     private func popVC() {
         print("✨ pop viewcontroller")
+        navigationController?.dismiss(animated: true)
     }
     @objc
     private func modifyInfo() {
@@ -63,16 +69,10 @@ class ProfileViewController: UIViewController {
             make.height.equalTo(UIScreen.main.bounds.height)        
         }
     }
-    private func setNavigation() {
-        self.navigationController?.navigationBar.backgroundColor = .blackFour
-        self.navigationController?.navigationBar.barTintColor = .blackFour
-        self.navigationController?.navigationBar.isTranslucent = false
-        self.navigationController?.isNavigationBarHidden = false
-        // dummy data
-        self.navigationItem.title = "Jercy"
-        self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.whiteTwo]
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "arrowChevronBigLeft"), style: .plain, target: self, action: #selector(popVC))
+    private func setNavigationItems() {
+        setNavigationItems(title: "Jercy", backButtonImageName: "arrowChevronBigLeft", action: #selector(popVC))
         
+        // 추가 네비게이션 아이템
         let editBtn: UIButton = UIButton()
         editBtn.setImage(UIImage(named: "iconlyLightSetting"), for: .normal)
         editBtn.frame = CGRect(x: 0, y: 0, width: 44, height: 44)

--- a/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
@@ -44,6 +44,7 @@ class ProfileViewController: UIViewController {
     @objc
     private func modifyInfo() {
         print("✨ modify user info")
+        navigationController?.pushViewController(modifyVC, animated: true)
     }
     @objc
     private func pushSettingVC() {

--- a/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
@@ -35,7 +35,7 @@ class ProfileViewController: UIViewController {
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
     // MARK: - Actions

--- a/MobalMobal/MobalMobal/Signup/SignupViewController.swift
+++ b/MobalMobal/MobalMobal/Signup/SignupViewController.swift
@@ -76,6 +76,7 @@ class SignupViewController: UIViewController {
         self.view.backgroundColor = .backgroundColor
         
         setUIViewLayout()
+        setNavigationItems(title: "회원 가입", backButtonImageName: "arrowChevronBigLeft", action: #selector(backButtonTapped))
     }
     
     @objc
@@ -87,6 +88,13 @@ class SignupViewController: UIViewController {
         } else {
             button.setImage(UIImage(named: "iconlyLightCheckOn"), for: .normal)
         }
+    }
+    
+    @objc
+    func backButtonTapped() {
+        // 실제로는 pop이 되어야 함. dismiss는 임시코드
+        // navigationController?.popViewController(animated: true)
+        navigationController?.dismiss(animated: true)
     }
     
     private func setNicknameView() {

--- a/MobalMobal/MobalMobal/Signup/SignupViewController.swift
+++ b/MobalMobal/MobalMobal/Signup/SignupViewController.swift
@@ -47,7 +47,7 @@ class SignupViewController: UIViewController {
     private let agreementLabel: UILabel = {
         let label: UILabel = UILabel()
         label.numberOfLines = 0
-        label.font = UIFont(name: "SpoqaHanSansNeo-Bold", size: 45)
+        label.font = UIFont(name: "SpoqaHanSansNeo-Bold", size: 15)
         label.text = "이용약관, 개인정보 수집 및 이용에 모두 동의 합니다."
         label.textColor = .white
         return label
@@ -56,7 +56,7 @@ class SignupViewController: UIViewController {
     private let completeButton: UIButton = {
         let button: UIButton = UIButton()
         button.layer.cornerRadius = 30
-        button.backgroundColor = UIColor(red: 71/255, green: 71/255, blue: 71/255, alpha: 1)
+        button.backgroundColor = UIColor(red: 71.0 / 255, green: 71.0 / 255, blue: 71.0 / 255, alpha: 1)
         return button
     }()
     
@@ -64,7 +64,7 @@ class SignupViewController: UIViewController {
         let label: UILabel = UILabel()
         label.text = "가입완료"
         label.font = UIFont(name: "SpoqaHanSansNeo-Medium", size: 18)
-        label.textColor = UIColor(red: 121/255, green: 121/255, blue: 121/255, alpha: 1)
+        label.textColor = UIColor(red: 121.0 / 255, green: 121.0 / 255, blue: 121.0 / 255, alpha: 1)
         return label
     }()
     
@@ -93,7 +93,7 @@ class SignupViewController: UIViewController {
         self.view.addSubview(nickNameView)
         self.nickNameView.snp.makeConstraints { make in
             make.height.equalTo(60)
-            make.top.equalToSuperview().inset(59)
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(59)
             make.leading.trailing.equalToSuperview().inset(15)
         }
     }

--- a/MobalMobal/MobalMobal/SuccessCharging/SuccessChargingViewController.swift
+++ b/MobalMobal/MobalMobal/SuccessCharging/SuccessChargingViewController.swift
@@ -59,6 +59,10 @@ class SuccessChargingViewController: UIViewController {
         super.viewDidLoad()
         self.view.backgroundColor = .backgroundColor
     }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
     override func updateViewConstraints() {
         if !setLayoutFlag {
             setViewHierarchy()

--- a/MobalMobal/MobalMobal/ViewController.swift
+++ b/MobalMobal/MobalMobal/ViewController.swift
@@ -16,7 +16,9 @@ class ViewController: UIViewController {
     // - MARK : 각자 view로 넘어감
     @IBAction private func firstButtonIsTapped(_ sender: UIButton) {
         let viewController = SignupViewController()
-        present(viewController, animated: true, completion: nil)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .fullScreen
+        present(navigationController, animated: true)
        
     }
     

--- a/MobalMobal/MobalMobal/ViewController.swift
+++ b/MobalMobal/MobalMobal/ViewController.swift
@@ -31,10 +31,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func fourthButtonIsTapped(_ sender: UIButton) {
-        let vc = ModifyProfileViewController()
-//        let navVc: UINavigationController = UINavigationController(rootViewController: vc)
-//        navVc.modalPresentationStyle = .overFullScreen
-        vc.modalPresentationStyle = .fullScreen
-        self.present(vc, animated: true, completion: nil)
+        let vc = ProfileViewController()
+        let navVc: UINavigationController = UINavigationController(rootViewController: vc)
+        navVc.modalPresentationStyle = .overFullScreen
+//        vc.modalPresentationStyle = .fullScreen
+        self.present(navVc, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### Related Issue
`Feature/navigation bar`
<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #75 


### What does this PR do?
- 🎨 **AppDelegate.swift**
모든 뷰컨트롤러에서 공통으로 사용될 `NavigationBarAppearance`를 설정했습니다.

- 🎨 **UIViewController+Extension.swift**
navigationItem의 title, back button, action handler를 설정해 줄 수 있는 함수를 만들었습니다. 
=> `setNavigationItems(title: backButtonName: action) `

- 🎨 **NavigationController를 사용하는 모든 뷰컨트롤러**
사용자 정의 메서드를 사용하여 중복 코드를 줄였습니다.
viewWillApear()에서 navigationBar를 숨길 것인지, 보여줄 것인지를 정해주었습니다.

### Why are we doing this?
- 공통으로 사용되는 Navigation Bar 속성은 중복해서 작성할 필요가 없습니다.
**AppDelegate**에서 초기 설정을 다 해놓았으므로 `background`, `title color`, `title font`, `button color`, `back button title color`는 각 뷰컨트롤러에서 별도로 지정해주지 않아도 됩니다.

- 각 뷰 컨트롤러마다 다르게 사용되는 Navigation Item 속성은 메서드를 정의해서 사용할 수 있습니다.
**viewDidLoad()** 에서 `setNavigationItems(title: backButtonName: action:)`를 사용하면 됩니다.

- NavigationBar는 뷰가 push, pop 되면서 hidden 되었다가 show 될 수도 있습니다.
ViewController가 **화면 위로 보일 때 마다** 숨김 또는 보임 처리 해주어야 하기 때문에 `viewWillAppear()`에서 처리해 주었습니다.
push pop 되는 동작은 애니메이션이 있기 때문에 **네비게이션 바**의 움직임도 자연스럽도록 하기 위해서 `setNavigationBarHidden(_: animated)` 를 사용했습니다.

### Additional
- 🐛회원가입 페이지 UI 잔버그도 수정했습니다.
- 💩ViewController.swift 4번째버튼 (서영) 링크는 프로필 화면으로 이동하게 변경하였습니다.
    - `프로필 페이지`에서 편집아이콘 버튼을 누르면 `프로필 수정 페이지`으로 이동합니다.
    - `프로필 페이지`에서 설정아이콘 버튼을 누르면 `충전 페이지`로 이동 가능합니다. (임시코드,,)

### Screenshots