### PR TITLE
🎨(#88) NetworkLayer 생성

### DIFF
--- a/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
+++ b/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
@@ -27,11 +27,16 @@
 		3AB1CFD6260F7CB200EA94E8 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1CFD5260F7CB200EA94E8 /* UIViewController+Extension.swift */; };
 		3AB1D0252610DB4700EA94E8 /* MainOngoingDonationHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB1D0242610DB4700EA94E8 /* MainOngoingDonationHeaderView.swift */; };
 		3AC393D9261CBC3D008BB207 /* DonationDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC393D8261CBC3D008BB207 /* DonationDetailViewModel.swift */; };
-		3AC393E5261CC08F008BB207 /* ServerURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC393E4261CC08F008BB207 /* ServerURL.swift */; };
 		3AC39404261DBDF5008BB207 /* DonationDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC39403261DBDF5008BB207 /* DonationDetailResponse.swift */; };
 		3AC39407261DBF59008BB207 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC39406261DBF59008BB207 /* Int+Extension.swift */; };
 		3AC3940E261DF7FC008BB207 /* JSONDecoder+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC3940D261DF7FC008BB207 /* JSONDecoder+Extension.swift */; };
 		3AC39411261DFBF2008BB207 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC39410261DFBF2008BB207 /* Date+Extension.swift */; };
+		4DBDB4E4261F53C900B5E08D /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 4DBDB4E3261F53C900B5E08D /* Moya */; };
+		4DBDB4EA261F542B00B5E08D /* DoneService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDB4E9261F542B00B5E08D /* DoneService.swift */; };
+		4DBDB4F2261F593F00B5E08D /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDB4F1261F593F00B5E08D /* MainViewModel.swift */; };
+		4DBDB4F5261F59A500B5E08D /* DoneProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDB4F4261F59A500B5E08D /* DoneProvider.swift */; };
+		4DBDB4F8261F614F00B5E08D /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDB4F7261F614F00B5E08D /* NetworkProvider.swift */; };
+		4DBDB4FC261F623600B5E08D /* MainResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDB4FB261F623600B5E08D /* MainResponse.swift */; };
 		6A7F9880C2DD6C6782A998EE /* Pods_MobalMobal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5C411755E7FEF436016D7E /* Pods_MobalMobal.framework */; };
 		7C04535625EA949B00870761 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C04535525EA949B00870761 /* ProfileViewController.swift */; };
 		7C04535A25EA98B900870761 /* ProfileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C04535925EA98B900870761 /* ProfileTableViewCell.swift */; };
@@ -103,11 +108,15 @@
 		3AB1CFD5260F7CB200EA94E8 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		3AB1D0242610DB4700EA94E8 /* MainOngoingDonationHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainOngoingDonationHeaderView.swift; sourceTree = "<group>"; };
 		3AC393D8261CBC3D008BB207 /* DonationDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DonationDetailViewModel.swift; sourceTree = "<group>"; };
-		3AC393E4261CC08F008BB207 /* ServerURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerURL.swift; sourceTree = "<group>"; };
 		3AC39403261DBDF5008BB207 /* DonationDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DonationDetailResponse.swift; sourceTree = "<group>"; };
 		3AC39406261DBF59008BB207 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		3AC3940D261DF7FC008BB207 /* JSONDecoder+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+Extension.swift"; sourceTree = "<group>"; };
 		3AC39410261DFBF2008BB207 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		4DBDB4E9261F542B00B5E08D /* DoneService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoneService.swift; sourceTree = "<group>"; };
+		4DBDB4F1261F593F00B5E08D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		4DBDB4F4261F59A500B5E08D /* DoneProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoneProvider.swift; sourceTree = "<group>"; };
+		4DBDB4F7261F614F00B5E08D /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
+		4DBDB4FB261F623600B5E08D /* MainResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainResponse.swift; sourceTree = "<group>"; };
 		5A5C411755E7FEF436016D7E /* Pods_MobalMobal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MobalMobal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61483D18A64727D4EAFF1EDD /* Pods-MobalMobal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MobalMobal.debug.xcconfig"; path = "Target Support Files/Pods-MobalMobal/Pods-MobalMobal.debug.xcconfig"; sourceTree = "<group>"; };
 		7C04535525EA949B00870761 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
@@ -150,6 +159,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4DBDB4E4261F53C900B5E08D /* Moya in Frameworks */,
 				D7147D6925E768B800AA0878 /* Toast in Frameworks */,
 				D7147D4925E763DC00AA0878 /* FirebaseMessaging in Frameworks */,
 				D7147D6525E7686800AA0878 /* FacebookCore in Frameworks */,
@@ -244,6 +254,24 @@
 			isa = PBXGroup;
 			children = (
 				3AC39403261DBDF5008BB207 /* DonationDetailResponse.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		4DBDB4E6261F540200B5E08D /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				4DBDB4E9261F542B00B5E08D /* DoneService.swift */,
+				4DBDB4F4261F59A500B5E08D /* DoneProvider.swift */,
+				4DBDB4F7261F614F00B5E08D /* NetworkProvider.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		4DBDB4FA261F622900B5E08D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				4DBDB4FB261F623600B5E08D /* MainResponse.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -363,7 +391,7 @@
 		D70C37C725E103DD00898271 /* MobalMobal */ = {
 			isa = PBXGroup;
 			children = (
-				3AC393E4261CC08F008BB207 /* ServerURL.swift */,
+				4DBDB4E6261F540200B5E08D /* Network */,
 				E3F1EA8025EA551F00F34BDE /* Setting */,
 				D7E44EEF25EA5133007FDB4F /* Main */,
 				3A179F4B25FB5A2100901436 /* DonateMoney */,
@@ -408,8 +436,10 @@
 		D7E44EEF25EA5133007FDB4F /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				4DBDB4FA261F622900B5E08D /* Model */,
 				D7AC0C9325EAB610000A342A /* cell */,
 				D7E44EF025EA5149007FDB4F /* MainViewController.swift */,
+				4DBDB4F1261F593F00B5E08D /* MainViewModel.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -476,6 +506,7 @@
 				D7147D6225E7686800AA0878 /* FacebookLogin */,
 				D7147D6425E7686800AA0878 /* FacebookCore */,
 				D7147D6825E768B800AA0878 /* Toast */,
+				4DBDB4E3261F53C900B5E08D /* Moya */,
 			);
 			productName = MobalMobal;
 			productReference = D70C37C525E103DD00898271 /* MobalMobal.app */;
@@ -512,6 +543,7 @@
 				D7147D5D25E766CC00AA0878 /* XCRemoteSwiftPackageReference "Then" */,
 				D7147D6125E7686800AA0878 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */,
 				D7147D6725E768B800AA0878 /* XCRemoteSwiftPackageReference "Toast-Swift" */,
+				4DBDB4E2261F53C900B5E08D /* XCRemoteSwiftPackageReference "Moya" */,
 			);
 			productRefGroup = D70C37C625E103DD00898271 /* Products */;
 			projectDirPath = "";
@@ -627,12 +659,14 @@
 				D7AC0C9525EAB9E2000A342A /* MainMyDonationCollectionViewCell.swift in Sources */,
 				D7AC0C9925EACAC8000A342A /* MainAddMyDonationCollectionViewCell.swift in Sources */,
 				3A6CFF3325EAEC7A00214E43 /* CustomLoginButton.swift in Sources */,
+				4DBDB4F5261F59A500B5E08D /* DoneProvider.swift in Sources */,
 				3AC39404261DBDF5008BB207 /* DonationDetailResponse.swift in Sources */,
+				4DBDB4F8261F614F00B5E08D /* NetworkProvider.swift in Sources */,
 				3A1BD71125ED26D00079D56D /* DonationDetailViewController.swift in Sources */,
+				4DBDB4EA261F542B00B5E08D /* DoneService.swift in Sources */,
 				3A1BD72425F1583D0079D56D /* DetailParticipantsMoreButtonView.swift in Sources */,
 				3A035F1825EA4D8C00D3FB69 /* LoginViewController.swift in Sources */,
 				3AC39407261DBF59008BB207 /* Int+Extension.swift in Sources */,
-				3AC393E5261CC08F008BB207 /* ServerURL.swift in Sources */,
 				3A1BD71D25F12F0C0079D56D /* DonationDetailViewController+Layout.swift in Sources */,
 				3A1BD73125F15EF20079D56D /* DetailParticipantsView.swift in Sources */,
 				7C39985D25FA51AA00EA82C2 /* AccountViewController.swift in Sources */,
@@ -644,7 +678,9 @@
 				E3692D1D25F4F9C500755FBF /* UIView+Extension.swift in Sources */,
 				3AB1CFD6260F7CB200EA94E8 /* UIViewController+Extension.swift in Sources */,
 				E3F1EAB225EACC9F00F34BDE /* SignupCustomView.swift in Sources */,
+				4DBDB4FC261F623600B5E08D /* MainResponse.swift in Sources */,
 				7C842FA02606267400A66756 /* ModifyProfileViewController.swift in Sources */,
+				4DBDB4F2261F593F00B5E08D /* MainViewModel.swift in Sources */,
 				7C04536025EAA2DC00870761 /* ProfileDonatingTableViewCell.swift in Sources */,
 				3AC393D9261CBC3D008BB207 /* DonationDetailViewModel.swift in Sources */,
 				7C04535D25EAA2C000870761 /* ProfileMyDonationTableViewCell.swift in Sources */,
@@ -882,6 +918,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4DBDB4E2261F53C900B5E08D /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 14.0.1;
+			};
+		};
 		D7147D3F25E763DC00AA0878 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
@@ -941,6 +985,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4DBDB4E3261F53C900B5E08D /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4DBDB4E2261F53C900B5E08D /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
 		D7147D4025E763DC00AA0878 /* FirebaseDynamicLinks */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D7147D3F25E763DC00AA0878 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/MobalMobal/MobalMobal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MobalMobal/MobalMobal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/firebase/abseil-cpp-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "05d8107f2971a37e6c77245b7c4c6b0a7e97bc99",
-          "version": "0.20200225.0"
+          "revision": "ff5f5f0a3d3266836b9d722bb73cabdf7057482e",
+          "version": "0.20200225.3"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/firebase/boringssl-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "7bcafa2660bc58715c39637494550d1ed7cd7229",
-          "version": "0.0.7"
+          "revision": "15889fadef7078dfa1392b0e2b08f3d0e9797104",
+          "version": "0.7.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "f4cd4db180486996d3b3216d11e7adf634695daa",
-          "version": "7.7.0"
+          "revision": "e73fdb6b83b489d3b037085e04a8381f14d7f009",
+          "version": "7.10.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "38205d8e39f806f71b048f93427337c9511c9402",
-          "version": "7.5.1"
+          "revision": "184d93b7790caa8b8368794c030c3aeb10d42e25",
+          "version": "7.10.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
         "state": {
           "branch": null,
-          "revision": "2e8a342494d20fcf209b61a45cddc1668b5ccc6d",
-          "version": "8.2.0"
+          "revision": "369716b8d7518a530ce3c3a251436d72546debd8",
+          "version": "8.4.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/firebase/grpc-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "91b62619e6c83bc5f1b99d9d60fe46b2862d3a5a",
-          "version": "1.28.2"
+          "revision": "fb405dd2c7901485f7e158b24e3a0a47e4efd8b5",
+          "version": "1.28.4"
         }
       },
       {
@@ -105,8 +105,26 @@
         "repositoryURL": "https://github.com/firebase/leveldb.git",
         "state": {
           "branch": null,
-          "revision": "fa1f25f296a766e5a789c4dacd4798dea798b2c2",
-          "version": "1.22.1"
+          "revision": "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+          "version": "1.22.2"
+        }
+      },
+      {
+        "package": "Logger",
+        "repositoryURL": "https://github.com/shibapm/Logger",
+        "state": {
+          "branch": null,
+          "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
+          "version": "0.2.3"
+        }
+      },
+      {
+        "package": "Moya",
+        "repositoryURL": "https://github.com/Moya/Moya.git",
+        "state": {
+          "branch": null,
+          "revision": "d27767c3624cc64a45bb371b267b89c92d70c670",
+          "version": "14.0.1"
         }
       },
       {
@@ -114,8 +132,35 @@
         "repositoryURL": "https://github.com/firebase/nanopb.git",
         "state": {
           "branch": null,
-          "revision": "c2d43e59d8ec880ed261366818f0cacc5c8cc2e6",
-          "version": "2.30907.0"
+          "revision": "7ee9ef9f627d85cbe1b8c4f49a3ed26eed216c77",
+          "version": "2.30908.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
+          "version": "8.1.2"
+        }
+      },
+      {
+        "package": "OHHTTPStubs",
+        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs.git",
+        "state": {
+          "branch": null,
+          "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+          "version": "9.1.0"
+        }
+      },
+      {
+        "package": "PackageConfig",
+        "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
+        "state": {
+          "branch": null,
+          "revision": "bf90dc69fa0792894b08a0b74cf34029694ae486",
+          "version": "0.13.0"
         }
       },
       {
@@ -125,6 +170,42 @@
           "branch": null,
           "revision": "afa9a1ace74e116848d4f743599ab83e584ff8cb",
           "version": "1.2.12"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "package": "ReactiveSwift",
+        "repositoryURL": "https://github.com/Moya/ReactiveSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "f195d82bb30e412e70446e2b4a77e1b514099e88",
+          "version": "6.1.0"
+        }
+      },
+      {
+        "package": "Rocket",
+        "repositoryURL": "https://github.com/shibapm/Rocket",
+        "state": {
+          "branch": null,
+          "revision": "25613f7ffd16105c74417c1b4eb4c93fd04e2cdf",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "254617dd7fae0c45319ba5fbea435bf4d0e15b5d",
+          "version": "5.1.2"
         }
       },
       {
@@ -146,6 +227,15 @@
         }
       },
       {
+        "package": "SwiftShell",
+        "repositoryURL": "https://github.com/kareman/SwiftShell",
+        "state": {
+          "branch": null,
+          "revision": "a6014fe94c3dbff0ad500e8da4f251a5d336530b",
+          "version": "5.1.0-beta.1"
+        }
+      },
+      {
         "package": "Then",
         "repositoryURL": "https://github.com/devxoul/Then.git",
         "state": {
@@ -161,6 +251,15 @@
           "branch": null,
           "revision": "0c9493eeacb102cc614da385cfaaf475379f4ab4",
           "version": "5.0.1"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams",
+        "state": {
+          "branch": null,
+          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
+          "version": "2.0.0"
         }
       }
     ]

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
@@ -23,7 +23,7 @@ class DonationDetailViewModel {
     private var donationId: Int = -1 { // id가 정해지면 API 통신
         didSet { callDonationInfoAPI() }
     }
-    private var detailResponse: DonationDetailResponse? { // 응답이 들어오면 값 세팅
+    private var detailResponse: DonationDetailData? { // 응답이 들어오면 값 세팅
         didSet { setDonationInfo() }
     }
     private lazy var donationImageURL: String? = nil { // 이미지
@@ -59,7 +59,7 @@ class DonationDetailViewModel {
     }
     
     private func setDonationInfo() {
-        guard let info = detailResponse?.data?.post else { return }
+        guard let info = detailResponse?.post else { return }
         
         self.donationImageURL = info.postImage
         self.donationPublisherName = "\(info.userId)번 사용자" // 유저 id가 아닌 닉네임 가져와야 함!
@@ -72,31 +72,10 @@ class DonationDetailViewModel {
     
     // MARK: - API Method
     func callDonationInfoAPI() {
-        let url: String = "\(ServerURL.detailURL)/\(donationId)"
-
-        AF.request(url, method: .get, encoding: JSONEncoding.default).responseJSON { [weak self] response in
-            switch response.result {
-            case .success(let data):
-                print("🐻 Detail Response: \(data)")
-                self?.detailResponse = try? self?.parse(detail: data)
-            case .failure(let error):
-                print("🐻 Detail API Error: \(error)")
-            }
-        }
-    }
-    
-    private func parse(detail value: Any) throws -> DonationDetailResponse {
-        do {
-            let data: Data = try JSONSerialization.data(withJSONObject: value, options: .prettyPrinted)
-            let decoder: JSONDecoder = JSONDecoder()
-            decoder.dateDecodingStrategy = try .iso8610WithZ()
-            
-            let parsedResponse: DonationDetailResponse = try decoder.decode(DonationDetailResponse.self, from: data)
-            print("🐻 Detail Parsed Data: \(parsedResponse)")
-            return parsedResponse
-        } catch let error {
-            print("🐻 Detail Response Decode Error: \(error)")
-            throw error
+        DoneProvider.getDonationDetail(postId: donationId) { [weak self] response in
+            self?.detailResponse = response.data
+        } failure: { _ in
+            return
         }
     }
 }

--- a/MobalMobal/MobalMobal/DonationDetail/Model/DonationDetailResponse.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/Model/DonationDetailResponse.swift
@@ -39,14 +39,3 @@ struct DetailData: Codable {
 struct DonationDetailData: Codable {
     let post: DetailData
 }
-
-enum ResponseState: Int, Codable {
-    case success = 200
-    case missingParam = 400
-}
-
-struct DonationDetailResponse: Codable {
-    let code: ResponseState
-    let data: DonationDetailData?
-    let message: String?
-}

--- a/MobalMobal/MobalMobal/Main/MainViewModel.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  MainViewModel.swift
+//  MobalMobal
+//
+//  Created by 이재성 on 2021/04/09.
+//
+
+import Foundation
+
+class MainViewModel {
+    // MARK: - API Method
+    func callMainInfoApi() {
+//        DoneProvider.getMain(item: <#T##Int#>, limit: <#T##Int#>, success: <#T##(ParseResponse<MainResponse>) -> Void#>, failure: <#T##(Error) -> Void#>)
+    }
+}

--- a/MobalMobal/MobalMobal/Main/Model/MainResponse.swift
+++ b/MobalMobal/MobalMobal/Main/Model/MainResponse.swift
@@ -1,0 +1,11 @@
+//
+//  MainResponse.swift
+//  MobalMobal
+//
+//  Created by 이재성 on 2021/04/09.
+//
+
+import Foundation
+
+struct MainResponse: Decodable {
+}

--- a/MobalMobal/MobalMobal/Network/DoneProvider.swift
+++ b/MobalMobal/MobalMobal/Network/DoneProvider.swift
@@ -1,0 +1,18 @@
+//
+//  DoneProvider.swift
+//  MobalMobal
+//
+//  Created by 이재성 on 2021/04/09.
+//
+
+import Foundation
+
+enum DoneProvider {
+    static func getMain(item: Int, limit: Int, success: @escaping (ParseResponse<MainResponse>) -> Void, failure: @escaping (Error) -> Void) {
+        NetworkProvider.request(.getMain(item: item, limit: limit), to: MainResponse.self, success: success, failure: failure)
+    }
+    
+    static func getDonationDetail(postId: Int, success: @escaping (ParseResponse<DonationDetailData>) -> Void, failure: @escaping (Error) -> Void) {
+        NetworkProvider.request(.getDetail(posts: postId), to: DonationDetailData.self, success: success, failure: failure)
+    }
+}

--- a/MobalMobal/MobalMobal/Network/DoneService.swift
+++ b/MobalMobal/MobalMobal/Network/DoneService.swift
@@ -1,0 +1,80 @@
+//
+//  DoneService.swift
+//  MobalMobal
+//
+//  Created by 이재성 on 2021/04/09.
+//
+
+import Foundation
+import Moya
+
+enum DoneService {
+    case login(fireStoreId: String)
+    case getMain(item: Int, limit: Int)
+    case getDetail(posts: Int)
+}
+
+extension DoneService: TargetType {
+    var sampleData: Data {
+        Data()
+    }
+    
+    var baseURL: URL {
+        return URL(string: "http://13.125.168.51:3000")!
+    }
+    
+    var path: String {
+        switch self {
+        case .getMain:
+            return "/posts"
+        case .login:
+            return "/users/login"
+        case .getDetail(let posts):
+            return "/posts/\(posts)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getMain, .getDetail:
+            return .get
+        case .login:
+            return .post
+            
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .getMain(let item, let limit):
+            return .requestParameters(parameters: ["item": item,
+                                                   "limit": limit,
+                                                   "order": "ASC"], encoding: URLEncoding.queryString)
+        case .getDetail:
+            return .requestPlain
+        case .login(let fireStoreId):
+            return .requestParameters(parameters: ["fireStoreId": fireStoreId], encoding: JSONEncoding.default)
+        }
+    }
+    
+    var headers: [String: String]? {
+        switch self {
+        case .login:
+            return nil
+        case .getMain, .getDetail:
+//            guard let token = token else { return nil }
+            return ["authorization": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJpYXQiOjE2MTc3ODIzNzgsImV4cCI6MTY0OTMzOTk3OCwiaXNzIjoiaHllb25pIn0.EylJ0O9zsOePeB6WmQ5-Xfm6X63L29s6iUxZL6dxzdA"]
+        }
+    }
+}
+
+// MARK: - Helpers
+private extension String {
+    var urlEscaped: String {
+        return addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
+    }
+
+    var utf8Encoded: Data {
+        return data(using: .utf8)!
+    }
+}

--- a/MobalMobal/MobalMobal/Network/NetworkProvider.swift
+++ b/MobalMobal/MobalMobal/Network/NetworkProvider.swift
@@ -1,0 +1,67 @@
+//
+//  NetworkProvider.swift
+//  MobalMobal
+//
+//  Created by 이재성 on 2021/04/09.
+//
+
+import Foundation
+import Moya
+
+struct ParseResponse<Response: Decodable>: Decodable {
+    var code: Int
+    var data: Response
+    var message: String?
+}
+
+enum DoneError: Error {
+  case noData
+  case client
+  case server
+  case unknown
+}
+
+enum NetworkProvider {
+    // MARK: Properties
+    private static let provider: MoyaProvider<DoneService> = MoyaProvider<DoneService>()
+    
+    // MARK: Method
+    static func request<Response: Decodable>(_ target: DoneService, to type: Response.Type, success: @escaping (ParseResponse<Response>) -> Void, failure: @escaping (Error) -> Void) {
+        request(target) { data in
+            do {
+                let parseData: ParseResponse<Response> = try parse(data)
+                print("\(parseData)")
+                success(parseData)
+            } catch {
+                print("🛑 Parse Fail: \(error)")
+                failure(error)
+            }
+        } failure: { failure($0) }
+    }
+    
+    private static func request(_ target: DoneService, success: @escaping (Data) -> Void, failure: @escaping (Error) -> Void) {
+        provider.session.sessionConfiguration.timeoutIntervalForRequest = 5
+        provider.request(target) { result in
+            switch result {
+            case .success(let response):
+                if 400..<500 ~= response.statusCode {
+                    print("🛑 400..<500 Client Error \(response)")
+                    failure(DoneError.client)
+                } else if 500..<600 ~= response.statusCode {
+                    print("🛑 500..<600 Server Error \(response)")
+                    failure(DoneError.server)
+                }
+                success(response.data)
+            case .failure(let error):
+                print("🛑 ServerError \(error)")
+                failure(error)
+            }
+        }
+    }
+    
+    private static func parse<Response: Decodable>(_ data: Data) throws -> ParseResponse<Response> {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = try .iso8610WithZ()
+        return try JSONDecoder().decode(ParseResponse<Response>.self, from: data)
+    }
+}


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #88

### What does this PR do?
- Moya 기반으로 Network Layer 생성
- https://github.com/Moya/Moya/blob/master/docs/Examples/Basic.md

### 사용방법
1. 새로 추가되는 api들은 먼저 DoneService enum에 등록
``` Swift
enum DoneService {
    case login(fireStoreId: String)
    case getMain(item: Int, limit: Int)
    case getDetail(posts: Int)
}
```

2. 아래 switch문들에 추가된 요청형식 작성
3. DoneProvider에 아래와 같이 함수 작성
``` Swift
    static func 함수명(파라미터, success: @escaping (ParseResponse<!받을응답리스폰스!>) -> Void, failure: @escaping (Error) -> Void) {
        NetworkProvider.request(.호출할api(파라미터), to: 받을응답리스폰스, success: success, failure: failure)
    }

    static func getDonationDetail(postId: Int, success: @escaping (ParseResponse<DonationDetailData>) -> Void, failure: @escaping (Error) -> Void) {
        NetworkProvider.request(.getDetail(posts: postId), to: DonationDetailData.self, success: success, failure: failure)
    }
```
4. 뷰컨에서 사용시 아래와 같이
``` Swift
        DoneProvider.getDonationDetail(postId: donationId) { [weak self] response in
            self?.detailResponse = response.data
        } failure: { _ in
            return
        }
```
### Why are we doing this?
- 현재 네트워크 통신과 파싱을 각각 화면별로 다 하고 있어서 중복되는 코드가 많아 레이어를 둬 정리하였습니다.

### Screenshots