### PR TITLE
✨ (#33) 후원할 때 잔액 확인하는 스텝 추가

### DIFF
--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
@@ -65,6 +65,10 @@ class DonateMoneyViewController: DoneBaseViewController {
     private func dismissViewController() {
         navigationController?.dismiss(animated: true, completion: nil)
     }
+    private func pushPointChargingVC() {
+        let pointCharging: PointChargingViewController = PointChargingViewController()
+        navigationController?.pushViewController(pointCharging, animated: false)
+    }
     
     // MARK: - Methods
     private func setConstraints() {
@@ -81,6 +85,16 @@ class DonateMoneyViewController: DoneBaseViewController {
     private func setViewTapGesture() {
         let clearViewTap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissViewController))
         clearView.addGestureRecognizer(clearViewTap)
+    }
+    private func showInsufficientPointAlert() {
+        let alert: UIAlertController = UIAlertController(title: "포인트 잔액 부족", message: "포인트를 먼저 충전해주세요", preferredStyle: .alert)
+        let cancelAction: UIAlertAction = UIAlertAction(title: "취소", style: .cancel)
+        let moveAction: UIAlertAction = UIAlertAction(title: "충전 페이지로", style: .default) { [weak self] _ in
+            self?.pushPointChargingVC()
+        }
+        alert.addAction(cancelAction)
+        alert.addAction(moveAction)
+        present(alert, animated: true)
     }
     private func showDonateFailAlert(message: String?) {
         var alertMessage: String = "에러가 발생했습니다. 잠시 후 다시 시도해주세요."
@@ -154,6 +168,10 @@ extension DonateMoneyViewController: UITableViewDataSource {
 }
 
 extension DonateMoneyViewController: DonateMoneyViewModelDelegate {
+    func insufficientPoint() {
+        showInsufficientPointAlert()
+    }
+    
     func failDonateMoney(message: String?) {
         showDonateFailAlert(message: message)
     }

--- a/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
@@ -200,9 +200,23 @@ class InputDonationMoneyViewController: DoneBaseViewController {
         alert.addAction(okAction)
         present(alert, animated: true)
     }
+    private func showInsufficientPointAlert() {
+        let alert: UIAlertController = UIAlertController(title: "포인트 잔액 부족", message: "포인트를 먼저 충전해주세요", preferredStyle: .alert)
+        let cancelAction: UIAlertAction = UIAlertAction(title: "취소", style: .cancel)
+        let moveAction: UIAlertAction = UIAlertAction(title: "충전 페이지로", style: .default) { [weak self] _ in
+            self?.pushPointChargingVC()
+        }
+        alert.addAction(cancelAction)
+        alert.addAction(moveAction)
+        present(alert, animated: true)
+    }
     @objc
     private func dismissNavigationController() {
         navigationController?.dismiss(animated: true, completion: nil)
+    }
+    private func pushPointChargingVC() {
+        let pointCharging: PointChargingViewController = PointChargingViewController()
+        navigationController?.pushViewController(pointCharging, animated: false)
     }
 }
 
@@ -272,6 +286,10 @@ extension InputDonationMoneyViewController: UITextFieldDelegate {
 }
 
 extension InputDonationMoneyViewController: DonateMoneyViewModelDelegate {
+    func insufficientPoint() {
+        showInsufficientPointAlert()
+    }
+    
     func failDonateMoney(message: String?) {
         print("🐻 Donation fail: \(message!)")
         showFailAlert()


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #33

### What does this PR do?
- 후원하려는 금액보다 충전된 잔액이 적을 경우 Alert를 띄웁니다.
- Alert를 통해 작업을 취소할 수 도 있고, 후원페이지로 이동할 수도 있습니다.

### Why are we doing this?
- PointCharging(충전페이지)와 DonateMoney(후원페이지)가 비슷하게 생겨서 충전페이지로 이동하기 전 Alert를 추가하였습니다.
    - 이 부분은 의견 주시는 대로 고쳐서 추가 작업 하겠습니다!
- DonateMoneyInputViewController 불투명한 백그라운드인데, 투명한 백그라운드인 PointChargingViewController를 push하면 애니메이션이 부자연스러워서 `animate: false` 로 설정하였습니다.

### Screenshots
<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/8906d5ab-01dd-4634-95b5-d83f70a93b7b/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210428%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210428T155541Z&X-Amz-Expires=86400&X-Amz-Signature=64a4b4726607d9c68d98884658fc42d7fbea0dbb2772618e6006dba955deb35f&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22" width="400">
<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/1ed1fc59-022f-4710-8581-a61bef5e9520/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210428%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210428T155745Z&X-Amz-Expires=86400&X-Amz-Signature=76b930ed947e04fd991d91b602b016c5f60d3196797df7f4945b7858a41650f0&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22" width="400">
<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/2fa6967c-5d9a-4fe0-9955-f467a628f8b8/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210428%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210428T155758Z&X-Amz-Expires=86400&X-Amz-Signature=9ce87b759118ff4fbb4845c37a227e6346c481f3ab80fcfb9a67b7a05d1459da&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22" width="400">
