### PR TITLE
(#115) CollectionViewCell 재사용으로 인한 이미지 적용문제 해결 (Feature/cell image download)

### DIFF
--- a/MobalMobal/MobalMobal/Main/MainViewController.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewController.swift
@@ -199,7 +199,6 @@ class MainViewController: DoneBaseViewController {
 extension MainViewController: UICollectionViewDelegate {
     // 스크롤 - 헤더뷰 사이즈 조정
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        print(scrollView.contentOffset.y)
         if scrollView.contentOffset.y <= 0 {
             if lastMinContentOffset > scrollView.contentOffset.y {
                 lastMinContentOffset = scrollView.contentOffset.y
@@ -227,8 +226,7 @@ extension MainViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch indexPath.section {
         case 1:
-            print("🐰 진행중 도네이션 : \(indexPath.item)")
-            presentDonationDetailVC(donationId: indexPath.item)
+            presentDonationDetailVC(donationId: viewModel.posts[indexPath.item].postID)
         default:
             break
         }
@@ -374,6 +372,6 @@ extension MainViewController: MainMyDonationCollectionViewCellDelegate {
     
     func didSelectMyOngoingDonationItem(at indexPath: IndexPath) {
         print("🐰 나의 진행 도네이션 : \(indexPath.item)")
-        presentDonationDetailVC(donationId: indexPath.item)
+        presentDonationDetailVC(donationId: indexPath.item) // viewModel.posts[indexPath.item].postID
     }
 }

--- a/MobalMobal/MobalMobal/Main/MainViewController.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김재희 on 2021/02/27.
 //
 
+import Kingfisher
 import SnapKit
 import Then
 import UIKit
@@ -260,38 +261,15 @@ extension MainViewController: UICollectionViewDataSource {
         }
     }
     
-    private func isIndicatorCell(_ indexPath: IndexPath) -> Bool {
-        if viewModel.posts.isEmpty { return false }
-        return indexPath.item == viewModel.posts.count
-    }
-    
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch indexPath.section {
         case 0:
-            guard let cell: MainMyDonationCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: myCellIdentifier, for: indexPath) as? MainMyDonationCollectionViewCell else { return .init() }
-            cell.delegate = self
-            return cell
-            
+            return getMyDonationCell(indexPath)
         default:
             if isIndicatorCell(indexPath) {
-                guard let cell: MainIndicatorCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: indicatorCellIdentifier, for: indexPath) as? MainIndicatorCollectionViewCell else { return .init() }
-                cell.animationIndicatorView()
-                return cell
+                return getIndicatorCell(indexPath)
             }
-            
-            guard let cell: MainOngoingDonationCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: ongoingCellIdentifier, for: indexPath) as? MainOngoingDonationCollectionViewCell else { return .init() }
-            
-            if !viewModel.posts.isEmpty {
-                let post = viewModel.posts[indexPath.item]
-                guard let money = post.currentAmount.changeToCommaFormat() else { return .init() }
-                cell.setModel(OngoingDonationModel(imageUrl: post.postImage,
-                                                   dday: Date().getDDayString(to: post.endAt),
-                                                   money: money,
-                                                   title: post.title,
-                                                   progress: Float(post.currentAmount) / Float(post.goal)
-                ))
-            }
-            return cell
+            return getDonationCell(indexPath)
         }
     }
     
@@ -303,6 +281,47 @@ extension MainViewController: UICollectionViewDataSource {
         default:
             return .init()
         }
+    }
+    
+    private func isIndicatorCell(_ indexPath: IndexPath) -> Bool {
+        if viewModel.posts.isEmpty { return false }
+        return indexPath.item == viewModel.posts.count
+    }
+    
+    private func getMyDonationCell(_ indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell: MainMyDonationCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: myCellIdentifier, for: indexPath) as? MainMyDonationCollectionViewCell else { return .init() }
+        cell.delegate = self
+        return cell
+    }
+    
+    private func getIndicatorCell(_ indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell: MainIndicatorCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: indicatorCellIdentifier, for: indexPath) as? MainIndicatorCollectionViewCell else { return .init() }
+        cell.animationIndicatorView()
+        return cell
+    }
+    
+    private func getDonationCell(_ indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell: MainOngoingDonationCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: ongoingCellIdentifier, for: indexPath) as? MainOngoingDonationCollectionViewCell else { return .init() }
+        
+        if viewModel.posts.isEmpty { return cell }
+        let post = viewModel.posts[indexPath.item]
+        let progress = Float(post.currentAmount) / Float(post.goal)
+        cell.setModel(dday: post.endAt, money: post.currentAmount, title: post.title, progress: progress, indexPath: indexPath)
+        
+        // 이미지 다운로드 후 인덱스 비교하여 셋팅
+        cell.setImage(nil)
+        guard let urlString: String = post.postImage, let imageURL: URL = URL(string: urlString) else { return cell }
+        KingfisherManager.shared.retrieveImage(with: imageURL) { result in
+            switch result {
+            case .success(let value):
+                if cell.isIndexPathEqual(with: indexPath) {
+                    cell.setImage(value.image)
+                }
+            default:
+                break
+            }
+        }
+        return cell
     }
 }
 
@@ -364,6 +383,7 @@ extension MainViewController: UICollectionViewDelegateFlowLayout {
     }
 }
 
+// MARK: - MainMyDonationCollectionViewCellDelegate
 extension MainViewController: MainMyDonationCollectionViewCellDelegate {
     func didSelectAddMyDonationButton() {
         print("🐰 나의 도네이션 추가하기")

--- a/MobalMobal/MobalMobal/Main/cell/MainOngoingDonationCollectionViewCell.swift
+++ b/MobalMobal/MobalMobal/Main/cell/MainOngoingDonationCollectionViewCell.swift
@@ -10,18 +10,18 @@ import SnapKit
 import UIKit
 
 struct OngoingDonationModel {
-    let imageUrl: String?
-    let dday: String
-    let money: String
+    let dday: Date
+    let money: Int
     let title: String
     let progress: Float
+    let indexPath: IndexPath
 }
 
 class MainOngoingDonationCollectionViewCell: UICollectionViewCell {
     // MARK: - UIComponents
-    private let thumbnailImageView: UIImageView = {
+    private lazy var thumbnailImageView: UIImageView = {
         let imageView: UIImageView = UIImageView()
-        imageView.image = UIImage(named: "profile_default")
+        imageView.image = placeholderImage
         imageView.backgroundColor = .white
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
@@ -75,6 +75,7 @@ class MainOngoingDonationCollectionViewCell: UICollectionViewCell {
     }()
     
     // MARK: - Properties
+    let placeholderImage: UIImage = UIImage(named: "profile_default")!
     private var model: OngoingDonationModel {
         didSet {
             populate()
@@ -83,7 +84,7 @@ class MainOngoingDonationCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Initializer
     override init(frame: CGRect) {
-        self.model = OngoingDonationModel(imageUrl: nil, dday: "D", money: "0", title: "title", progress: 0.0)
+        self.model = OngoingDonationModel(dday: Date(), money: 0, title: "갖고 싶은 물건", progress: 0.0, indexPath: IndexPath(item: -1, section: -1))
         super.init(frame: .zero)
         contentView.backgroundColor = .darkGrey
         contentView.layer.cornerRadius = 12
@@ -104,7 +105,6 @@ class MainOngoingDonationCollectionViewCell: UICollectionViewCell {
             make.edges.equalTo(thumbnailImageView)
         }
         progressBackgroundView.snp.makeConstraints { make in
-//            make.centerY.equalTo(translucentView.snp.bottom)
             make.top.equalTo(thumbnailImageView.snp.bottom)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(2)
@@ -126,17 +126,22 @@ class MainOngoingDonationCollectionViewCell: UICollectionViewCell {
     }
     
     // MARK: - Methods
-    func setModel(_ model: OngoingDonationModel) {
-        self.model = model
+    func isIndexPathEqual(with indexPath: IndexPath) -> Bool {
+        self.model.indexPath == indexPath
     }
-    
-    private func populate() {
-        if let url = model.imageUrl {
-            let imageURL: URL? = URL(string: url)
-            thumbnailImageView.kf.setImage(with: imageURL)
+    func setModel(dday: Date, money: Int, title: String, progress: Float, indexPath: IndexPath) {
+        self.model = OngoingDonationModel(dday: dday, money: money, title: title, progress: progress, indexPath: indexPath)
+    }
+    func setImage(_ image: UIImage?) {
+        guard let image = image else {
+            self.thumbnailImageView.image = placeholderImage
+            return
         }
-        dDayLabel.text = model.dday
-        moneyLabel.text = model.money
+        self.thumbnailImageView.image = image
+    }
+    private func populate() {
+        dDayLabel.text = Date().getDDayString(to: model.dday)
+        moneyLabel.text = model.money.changeToCommaFormat()
         titleLabel.text = model.title
         progressBarView.snp.removeConstraints()
         progressBackgroundView.addSubview(progressBarView)


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #115 

### What does this PR do?
- ViewModel에서 실제 터치된 셀의 postID 값을 전달 -> 상세페이지로 이동
- CollectionView cell 재사용으로 인한 이미지 적용 문제 해결 (이미지 다운로드 완료 후 IndexPath 비교하여 적용)
- CollectionView 섹션별 cell을 반환하는 함수 분리

### Why are we doing this?
- 컬렉션뷰 셀은 재사용되므로 이미지 갱신에 문제가 발생하였습니다.
  - URL이 없는 경우 (nil) : placeholder 이미지로 대체
  - URL이 잘못된 경우 : placeholder 이미지로 대체
  - URL이 정상일 경우 : 이미지 다운로드 완료 후, 현재 IndexPath와 cell의 IndexPath가 같은지 비교 후 적용

### Screenshots
<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/d99b65e2-8539-4131-a96e-96b01a3051da/1690D36A-B63D-42C4-BCD9-B2E642082142.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210503%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210503T091112Z&X-Amz-Expires=86400&X-Amz-Signature=39b5e3bfd0c14758ef55335765258d769102202febc543a82279f4e03ac70a39&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%221690D36A-B63D-42C4-BCD9-B2E642082142.png%22" height="600"> <img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/c37fee55-3b02-4d10-882f-0b245fc1304b/855A07A1-93CC-4C25-9495-2CEE5E710990.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210503%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210503T091334Z&X-Amz-Expires=86400&X-Amz-Signature=74beff4534d6248dbf26472e747cbd0c5cdfe756e3c1a7745f710683185b22a1&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22855A07A1-93CC-4C25-9495-2CEE5E710990.png%22" height="600">