### PR TITLE
(#107) [상세페이지] 올바른 정보 표시 및 UI 개선 (Feature/detail UI)

### DIFF
--- a/MobalMobal/MobalMobal/DonateComplete/DonateCompleteViewController.swift
+++ b/MobalMobal/MobalMobal/DonateComplete/DonateCompleteViewController.swift
@@ -84,6 +84,9 @@ class DonateCompleteViewController: UIViewController {
         return stackView
     }()
     
+    // MARK: - Properties
+    var donationCompletionHander: () -> Void = {}
+    
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -119,6 +122,7 @@ class DonateCompleteViewController: UIViewController {
     
     @objc
     private func clickCloseButton() {
+        donationCompletionHander()
         navigationController?.dismiss(animated: true)
     }
 }

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
@@ -27,6 +27,7 @@ class DonateMoneyViewController: DoneBaseViewController {
     
     // MARK: - Properties
     private lazy var viewModel: DonateMoneyViewModel = DonateMoneyViewModel(delegate: self)
+    var donationCompletionHander: () -> Void = {}
     
     private let headerString: String = "후원"
     private let cellIdentifier: String = "DonateMoneyTableViewCell"
@@ -180,6 +181,7 @@ extension DonateMoneyViewController: DonateMoneyViewModelDelegate {
         print("🐻 Donation Success")
         // 후원완료 페이지로 이동
         let completeVC: DonateCompleteViewController = DonateCompleteViewController()
+        completeVC.donationCompletionHander = donationCompletionHander
         completeVC.modalPresentationStyle = .fullScreen
         navigationController?.pushViewController(completeVC, animated: true)
     }

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController+Layout.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController+Layout.swift
@@ -103,6 +103,7 @@ extension DonationDetailViewController {
     private func setWantLabelConstraints() {
         wantLabel.snp.makeConstraints { make in
             make.leading.equalTo(giftLabel.snp.trailing).offset(4)
+            make.trailing.equalToSuperview()
             make.bottom.equalTo(giftLabel)
         }
     }
@@ -116,6 +117,7 @@ extension DonationDetailViewController {
     private func setNameGiftGroupViewConstraints() {
         nameGiftGroupView.snp.makeConstraints { make in
             make.leading.equalTo(profileImageView.snp.trailing).offset(10)
+            make.trailing.equalToSuperview().inset(22)
             make.centerY.equalTo(profileImageView)
         }
     }

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController+Layout.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController+Layout.swift
@@ -91,6 +91,7 @@ extension DonationDetailViewController {
     private func setZosaLabelConstraints() {
         zosaLabel.snp.makeConstraints { make in
             make.leading.equalTo(nameLabel.snp.trailing).offset(5)
+            make.trailing.lessThanOrEqualToSuperview()
             make.bottom.equalTo(nameLabel)
         }
     }

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController+Layout.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController+Layout.swift
@@ -72,11 +72,10 @@ extension DonationDetailViewController {
     
     // MARK: - Mid Area
     func setMidDescriptionAreaConstraints() {
-        nameGiftGroupView.addSubviews([nameLabel, zosaLabel, giftLabel, wantLabel])
+        nameGiftGroupView.addSubviews([nameLabel, wantLabel, giftLabel])
         setNameLabelConstraints()
-        setZosaLabelConstraints()
-        setGiftLabelConstraints()
         setWantLabelConstraints()
+        setGiftLabelConstraints()
         
         contentView.addSubviews([profileImageView, nameGiftGroupView, descriptionLabel])
         setProfileImageViewConstraints()
@@ -88,9 +87,9 @@ extension DonationDetailViewController {
             make.top.leading.equalToSuperview()
         }
     }
-    private func setZosaLabelConstraints() {
-        zosaLabel.snp.makeConstraints { make in
-            make.leading.equalTo(nameLabel.snp.trailing).offset(5)
+    private func setWantLabelConstraints() {
+        wantLabel.snp.makeConstraints { make in
+            make.leading.equalTo(nameLabel.snp.trailing).offset(4)
             make.trailing.lessThanOrEqualToSuperview()
             make.bottom.equalTo(nameLabel)
         }
@@ -98,14 +97,7 @@ extension DonationDetailViewController {
     private func setGiftLabelConstraints() {
         giftLabel.snp.makeConstraints { make in
             make.top.equalTo(nameLabel.snp.bottom).offset(6)
-            make.leading.bottom.equalToSuperview()
-        }
-    }
-    private func setWantLabelConstraints() {
-        wantLabel.snp.makeConstraints { make in
-            make.leading.equalTo(giftLabel.snp.trailing).offset(4)
-            make.trailing.equalToSuperview()
-            make.bottom.equalTo(giftLabel)
+            make.leading.trailing.bottom.equalToSuperview()
         }
     }
     private func setProfileImageViewConstraints() {

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -59,8 +59,8 @@ class DonationDetailViewController: DoneBaseViewController {
     
     // Mid Description Area
     let nameGiftGroupView: UIView = UIView()
-    let profileImageView: UIImageView = {
-        let imageView: UIImageView = UIImageView(image: UIImage(named: "profile_default"))
+    lazy var profileImageView: UIImageView = {
+        let imageView: UIImageView = UIImageView(image: placeholderImage)
         imageView.contentMode = .scaleAspectFill
         imageView.layer.cornerRadius = 29
         imageView.layer.masksToBounds = true
@@ -68,6 +68,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let nameLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "누군가"
         label.font = .spoqaHanSansNeo(ofSize: 16, weight: .medium)
         label.textColor = .white
@@ -75,6 +76,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let zosaLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "는"
         label.font = .spoqaHanSansNeo(ofSize: 14, weight: .regular)
         label.textColor = .white
@@ -82,6 +84,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let giftLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "선물"
         label.font = .spoqaHanSansNeo(ofSize: 16, weight: .medium)
         label.textColor = .wheat
@@ -91,6 +94,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let wantLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "가지고 싶어요"
         label.font = .spoqaHanSansNeo(ofSize: 14, weight: .regular)
         label.textColor = .white
@@ -98,6 +102,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let descriptionLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "한마디"
         label.font = .spoqaHanSansNeo(ofSize: 14, weight: .regular)
         label.textColor = .white
@@ -113,6 +118,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let destinationTitleLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "목표 금액"
         label.font = .spoqaHanSansNeo(ofSize: 15, weight: .medium)
         label.textColor = .veryLightPink
@@ -120,6 +126,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let destinationNumberLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "0"
         label.font = .spoqaHanSansNeo(ofSize: 16, weight: .bold)
         label.textColor = UIColor.white.withAlphaComponent(0.5)
@@ -127,6 +134,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let fundAmountTitleLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "모금 금액"
         label.font = .spoqaHanSansNeo(ofSize: 15, weight: .medium)
         label.textColor = .veryLightPink
@@ -134,6 +142,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let fundAmountNumberLabel: UILabel = {
         let label: UILabel = UILabel()
+        label.textAlignment = .left
         label.text = "0"
         label.font = .spoqaHanSansNeo(ofSize: 16, weight: .bold)
         label.textColor = .lightBluishGreen
@@ -141,6 +150,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
 //    let participantsTitleLabel: UILabel = {
 //        let label: UILabel = UILabel()
+//        label.textAlignment = .left
 //        label.text = "참여자"
 //        label.font = .spoqaHanSansNeo(ofSize: 15, weight: .medium)
 //        label.textColor = .veryLightPink
@@ -148,6 +158,7 @@ class DonationDetailViewController: DoneBaseViewController {
 //    }()
 //    let participantsCountLabel: UILabel = {
 //        let label: UILabel = UILabel()
+    //        label.textAlignment = .left
 //        label.text = ""
 //        label.font = .spoqaHanSansNeo(ofSize: 15, weight: .medium)
 //        label.textColor = .veryLightPink

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -187,6 +187,7 @@ class DonationDetailViewController: DoneBaseViewController {
     
     // MARK: - Properties
     private lazy var viewModel: DonationDetailViewModel = DonationDetailViewModel(delegate: self)
+    let placeholderImage: UIImage? = UIImage(named: "profile_default")!
     
     // MARK: - Initializer
     init(donationId: Int) {
@@ -246,10 +247,10 @@ class DonationDetailViewController: DoneBaseViewController {
 extension DonationDetailViewController: DonationDetailViewModelDelegate {
     func didImageChanged(to url: String?) {
         guard let url = url else {
-            detailImageView.image = UIImage(named: "doneImage")
+            detailImageView.image = placeholderImage
             return
         }
-        detailImageView.kf.setImage(with: URL(string: url))
+        detailImageView.kf.setImage(with: URL(string: url), placeholder: placeholderImage)
     }
     func didPublisherChanged(to nickname: String) {
         nameLabel.text = nickname

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -250,6 +250,7 @@ class DonationDetailViewController: DoneBaseViewController {
 
 // MARK: - DonationDetailViewModelDelegate
 extension DonationDetailViewController: DonationDetailViewModelDelegate {
+    
     func didImageChanged(to url: String?) {
         guard let url = url else {
             detailImageView.image = placeholderImage
@@ -257,10 +258,23 @@ extension DonationDetailViewController: DonationDetailViewModelDelegate {
         }
         detailImageView.kf.setImage(with: URL(string: url), placeholder: placeholderImage)
     }
+    func didProfileImageChanged(to url: String?) {
+        guard let url = url else {
+            profileImageView.image = placeholderImage
+            return
+        }
+        profileImageView.kf.setImage(with: URL(string: url), placeholder: placeholderImage)
+    }
     func didPublisherChanged(to nickname: String) {
         nameLabel.text = nickname
-        
+        wantLabel.text = "\(getZosa(after: nickname))원하는"
         donationButton.setTitle("\(nickname)에게 후원하기", for: .normal)
+    }
+    func getZosa(after string: String) -> String {
+        guard let lastChar = string.last, let unicode = UnicodeScalar(String(lastChar))?.value else { return "" }
+        if unicode < 0xAC00 || unicode > 0xD7A3 { return "" } // 한글이 아니면 "" 반환
+        let fianlWord = (unicode - 0xAC00) % 28 // 종성 확인
+        return fianlWord > 0 ? "이 " : "가 " // 받침있으면 "이" 없으면 "가" 반환
     }
     func didTitleChanged(to title: String) {
         giftLabel.text = title

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -207,7 +207,13 @@ class DonationDetailViewController: DoneBaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundColor
+        setNavigationItems(title: "상세 보기", backButtonImageName: "arrowChevronBigLeft", action: #selector(clickBackButton))
         view.setNeedsUpdateConstraints()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
     override func updateViewConstraints() {
@@ -231,6 +237,10 @@ class DonationDetailViewController: DoneBaseViewController {
     private func clickDonationButton() {
         presentDonateMoneyVC()
     }
+    @objc
+    private func clickBackButton() {
+        popNavigationVC()
+    }
     
     // MARK: - Methods
     private func showParticipantsAlert() {
@@ -242,9 +252,16 @@ class DonationDetailViewController: DoneBaseViewController {
     
     private func presentDonateMoneyVC() {
         let donateMoneyVC: DonateMoneyViewController = DonateMoneyViewController(postId: viewModel.getDonationId() )
+        donateMoneyVC.donationCompletionHander = { [weak self] in
+            self?.viewModel.callDonationInfoAPI()
+        }
         let navigationController: UINavigationController = UINavigationController(rootViewController: donateMoneyVC)
         navigationController.modalPresentationStyle = .overFullScreen
         present(navigationController, animated: true)
+    }
+    
+    private func popNavigationVC() {
+        navigationController?.popViewController(animated: true)
     }
 }
 
@@ -278,6 +295,7 @@ extension DonationDetailViewController: DonationDetailViewModelDelegate {
     }
     func didTitleChanged(to title: String) {
         giftLabel.text = title
+        navigationItem.title = title
     }
     func didDesciptionChanged(to description: String) {
         descriptionLabel.text = description

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -32,7 +32,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }()
     let translucentView: UIView = {
         let view: UIView = UIView()
-        view.backgroundColor = .black70
+        view.backgroundColor = .black40
         return view
     }()
     let progressLabel: UILabel = {
@@ -69,15 +69,16 @@ class DonationDetailViewController: DoneBaseViewController {
     let nameLabel: UILabel = {
         let label: UILabel = UILabel()
         label.textAlignment = .left
+        label.lineBreakMode = .byTruncatingTail
         label.text = "누군가"
         label.font = .spoqaHanSansNeo(ofSize: 16, weight: .medium)
         label.textColor = .white
         return label
     }()
-    let zosaLabel: UILabel = {
+    let wantLabel: UILabel = {
         let label: UILabel = UILabel()
         label.textAlignment = .left
-        label.text = "는"
+        label.text = "가 원하는"
         label.font = .spoqaHanSansNeo(ofSize: 14, weight: .regular)
         label.textColor = .white
         return label
@@ -85,19 +86,12 @@ class DonationDetailViewController: DoneBaseViewController {
     let giftLabel: UILabel = {
         let label: UILabel = UILabel()
         label.textAlignment = .left
+        label.lineBreakMode = .byTruncatingTail
         label.text = "선물"
         label.font = .spoqaHanSansNeo(ofSize: 16, weight: .medium)
         label.textColor = .wheat
         label.drawShadow(color: .yellowTan80, blur: 10)
         label.layer.masksToBounds = false
-        return label
-    }()
-    let wantLabel: UILabel = {
-        let label: UILabel = UILabel()
-        label.textAlignment = .left
-        label.text = "가지고 싶어요"
-        label.font = .spoqaHanSansNeo(ofSize: 14, weight: .regular)
-        label.textColor = .white
         return label
     }()
     let descriptionLabel: UILabel = {
@@ -265,6 +259,7 @@ extension DonationDetailViewController: DonationDetailViewModelDelegate {
     }
     func didPublisherChanged(to nickname: String) {
         nameLabel.text = nickname
+        
         donationButton.setTitle("\(nickname)에게 후원하기", for: .normal)
     }
     func didTitleChanged(to title: String) {

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol DonationDetailViewModelDelegate: class {
     func didImageChanged(to url: String?)
+    func didProfileImageChanged(to url: String?)
     func didPublisherChanged(to nickname: String)
     func didTitleChanged(to title: String)
     func didDesciptionChanged(to description: String)
@@ -28,6 +29,9 @@ class DonationDetailViewModel {
     }
     private lazy var donationImageURL: String? = nil { // 이미지
         didSet { delegate?.didImageChanged(to: donationImageURL) }
+    }
+    private lazy var profileImageURL: String? = nil {
+        didSet { delegate?.didProfileImageChanged(to: profileImageURL) }
     }
     private lazy var donationPublisherName: String = "누군가" {
         didSet { delegate?.didPublisherChanged(to: donationPublisherName) }
@@ -62,7 +66,8 @@ class DonationDetailViewModel {
         guard let info = detailResponse?.post else { return }
         
         self.donationImageURL = info.postImage
-        self.donationPublisherName = "\(info.userId)번 사용자" // 유저 id가 아닌 닉네임 가져와야 함!
+        self.profileImageURL = info.user.profileImageURL
+        self.donationPublisherName = info.user.nickname
         self.donationTitle = info.title
         self.donationDescription = info.description ?? ""
         self.donationGoal = info.goal

--- a/MobalMobal/MobalMobal/DonationDetail/Model/DonationDetailResponse.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/Model/DonationDetailResponse.swift
@@ -7,6 +7,17 @@
 
 import Foundation
 
+struct PostPublisher: Codable {
+    let userId: Int
+    let nickname: String
+    let profileImageURL: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case nickname
+        case profileImageURL = "profile_image"
+    }
+}
 struct DetailData: Codable {
     let postId: Int
     let userId: Int
@@ -15,6 +26,7 @@ struct DetailData: Codable {
     let description: String?
     let goal: Int
     let current: Int
+    let user: PostPublisher
     
     let startedDate: Date?
     let endDate: Date?
@@ -26,7 +38,7 @@ struct DetailData: Codable {
         case postId = "post_id"
         case userId = "user_id"
         case postImage = "post_image"
-        case title, description, goal
+        case title, description, goal, user
         case current = "current_amount"
         case startedDate = "started_at"
         case endDate = "end_at"

--- a/MobalMobal/MobalMobal/Extension/UIColor+Additions.swift
+++ b/MobalMobal/MobalMobal/Extension/UIColor+Additions.swift
@@ -46,8 +46,8 @@ extension UIColor {
     return UIColor(white: 157.0 / 255.0, alpha: 1.0)
   }
 
-  @nonobjc class var black70: UIColor {
-    return UIColor(white: 16.0 / 255.0, alpha: 0.7)
+  @nonobjc class var black40: UIColor {
+    return UIColor(white: 16.0 / 255.0, alpha: 0.4)
   }
 
   @nonobjc class var blackTwo: UIColor {

--- a/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
+++ b/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
@@ -8,6 +8,7 @@
 import UIKit
 extension UIViewController {
     func setNavigationItems(title: String, backButtonImageName: String, action: Selector?) {
+        navigationController?.navigationBar.isTranslucent = false
         self.navigationItem.title = title
         
         guard let backButtonImage: UIImage = UIImage(named: backButtonImageName) else { return }

--- a/MobalMobal/MobalMobal/Main/MainViewController.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewController.swift
@@ -98,8 +98,7 @@ class MainViewController: DoneBaseViewController {
     // MARK: - Actions
     @objc
     private func touchProfileButton() {
-        print("🐰 프로필")
-        presentProfileVC()
+        pushProfileVC()
     }
     @objc
     private func touchNotiListButton() {
@@ -107,12 +106,9 @@ class MainViewController: DoneBaseViewController {
         presentNotiListVC()
     }
     
-    private func presentProfileVC() {
+    private func pushProfileVC() {
         let profileVC: ProfileViewController = ProfileViewController()
-        let navigation: UINavigationController = UINavigationController(rootViewController: profileVC)
-        navigation.modalPresentationStyle = .fullScreen
-        navigation.setNavigationBarHidden(false, animated: true)
-        present(navigation, animated: true)
+        navigationController?.pushViewController(profileVC, animated: true)
     }
     
     // 변경 가능

--- a/MobalMobal/MobalMobal/Main/MainViewController.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewController.swift
@@ -125,7 +125,7 @@ class MainViewController: DoneBaseViewController {
     
     func presentDonationDetailVC(donationId: Int) {
         let detailVC: DonationDetailViewController = DonationDetailViewController(donationId: donationId)
-        present(detailVC, animated: true)
+        self.navigationController?.pushViewController(detailVC, animated: true)
     }
     
     // 변경 가능

--- a/MobalMobal/MobalMobal/Main/MainViewController.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewController.swift
@@ -228,7 +228,7 @@ extension MainViewController: UICollectionViewDelegate {
         switch indexPath.section {
         case 1:
             print("🐰 진행중 도네이션 : \(indexPath.item)")
-            presentDonationDetailVC(donationId: indexPath.item)
+            presentDonationDetailVC(donationId: viewModel.posts[indexPath.item].postID)
         default:
             break
         }

--- a/MobalMobal/MobalMobal/Main/cell/MainOngoingDonationCollectionViewCell.swift
+++ b/MobalMobal/MobalMobal/Main/cell/MainOngoingDonationCollectionViewCell.swift
@@ -30,7 +30,7 @@ class MainOngoingDonationCollectionViewCell: UICollectionViewCell {
     
     private let translucentView: UIView = {
         let view: UIView = UIView()
-        view.backgroundColor = .black70
+        view.backgroundColor = .black40
         return view
     }()
     

--- a/MobalMobal/MobalMobal/MakeComplete/MakeCompleteViewController.swift
+++ b/MobalMobal/MobalMobal/MakeComplete/MakeCompleteViewController.swift
@@ -39,7 +39,7 @@ class MakeCompleteViewController: UIViewController {
     }()
     lazy var transparentView: UIView = {
         let view: UIView = UIView()
-        view.backgroundColor = .black70
+        view.backgroundColor = .black40
         return view
     }()
     lazy var ddayLabel: UILabel = {

--- a/MobalMobal/MobalMobal/Profile/Cell/ProfileDonatingTableViewCell.swift
+++ b/MobalMobal/MobalMobal/Profile/Cell/ProfileDonatingTableViewCell.swift
@@ -27,7 +27,7 @@ class ProfileDonatingTableViewCell: UITableViewCell {
     }()
     private let translucentView: UIView = {
         let view: UIView = UIView()
-        view.backgroundColor = .black70
+        view.backgroundColor = .black40
         return view
     }()
     private lazy var donateDday: UILabel = {

--- a/MobalMobal/MobalMobal/ViewController.swift
+++ b/MobalMobal/MobalMobal/ViewController.swift
@@ -24,8 +24,9 @@ class ViewController: DoneBaseViewController {
     
     @IBAction private func secondButtonIsTapped(_ sender: UIButton) {
         let mainVC: MainViewController = MainViewController(viewModel: MainViewModel())
-        mainVC.modalPresentationStyle = .fullScreen
-        self.present(mainVC, animated: true, completion: nil)
+        let navigation: UINavigationController = UINavigationController(rootViewController: mainVC)
+        navigation.modalPresentationStyle = .fullScreen
+        present(navigation, animated: true)
     }
     
     @IBAction private func thirdButtonIsTapped(_ sender: UIButton) {


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #107 

### What does this PR do?
- API 수정이 완료됨에 따라 user 객체에서 nickname과 profileImage를 가져와 적용하였습니다. 
- 이미지 placeholder를 설정해주었습니다.
- UI 개선
  - **이미지 반투명 뷰 alpha 값** : 70% ➡️ 40%
  - **title 문구 수정** : "oo는 xx 가지고 싶어요" ➡️ "oo(이)가 원하는 xx"
    - 문구가 길어질 경우 말줄임 처리
    - 닉네임 종성에 따른 조사 반영 (`~~이` or `~~가`, 영어일 경우 조사는 없음)
  - modal present 방식 ➡️ navigation push 방식 
  - 후원 완료 시, 후원 금액이 적용된 화면으로 갱신

### Why are we doing this?
- 이전에는 user_id 밖에 알 수 없었지만, api 수정이 완료되어 객체에서 `nickname`과 `profileImage`를 가져올 수 있게 되었습니다.
- **KingFisher**: imageView.kf.setImage() 에 있는 `placeholder` 파라미터를 사용하였습니다.
- 약간의 디자인 수정이 있었습니다.
- 상세페이지에서 뒤로 돌아가는 방법이 없어, <del>`별도의 종료버튼`</del> or **`네비게이션 백버튼`** 방식을 채택하였습니다.
- 후원이 완료되면 자연스럽게 금액이 갱신되도록 하였습니다. `viewWillApear()`는 호출되지 않으므로, completionHandler를 전달하여, 후원 완료 시점에 호출되도록 하였습니다.

### Screenshots
<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/1d11f73d-c25e-42db-9a1d-aafd58077225/Simulator_Screen_Shot_-_iPhone_11_Pro_-_2021-05-04_at_02.06.02.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210503%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210503T170850Z&X-Amz-Expires=86400&X-Amz-Signature=a0cc745048bf93196d8caecca7517ef7052d8643c048d474af78154890f348ff&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Simulator_Screen_Shot_-_iPhone_11_Pro_-_2021-05-04_at_02.06.02.png%22" height="600"> <img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/e6365bba-e4c0-4059-8216-56eade6cc6e9/Simulator_Screen_Shot_-_iPhone_11_Pro_-_2021-05-04_at_02.07.01.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210503%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210503T170904Z&X-Amz-Expires=86400&X-Amz-Signature=125b1bf3847e6cc083dd6aa6f726e8fb45b5693328e2f91e4dfec3cbedcd2793&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Simulator_Screen_Shot_-_iPhone_11_Pro_-_2021-05-04_at_02.07.01.png%22" height="600">