### PR TITLE
(#35) 후원완료 페이지 도네이션 정보 반영 (Feature/donation complete UI)

### DIFF
--- a/MobalMobal/MobalMobal/DonateComplete/DonateCompleteViewController.swift
+++ b/MobalMobal/MobalMobal/DonateComplete/DonateCompleteViewController.swift
@@ -18,7 +18,7 @@ class DonateCompleteViewController: UIViewController {
     }()
     lazy var nameLabel: UILabel = {
         let label: UILabel = UILabel()
-        label.text = "Jercy"
+        label.text = nickname
         label.font = .spoqaHanSansNeo(ofSize: 19, weight: .bold)
         label.textColor = .white
         return label
@@ -32,13 +32,13 @@ class DonateCompleteViewController: UIViewController {
     }()
     lazy var giftLabel: UILabel = {
         let label: UILabel = UILabel()
-        label.text = "PS5 가지고싶어요"
+        label.text = "\(giftName) 가지고 싶어요"
         label.font = .spoqaHanSansNeo(ofSize: 19, weight: .regular)
         label.textColor = .white
         return label
     }()
-    let completeImageView: UIImageView = {
-        let image: UIImage = UIImage(named: "doneImage")!
+    lazy var completeImageView: UIImageView = {
+        let image: UIImage = placeholderImage
         let imageView: UIImageView = UIImageView(image: image)
         return imageView
     }()
@@ -51,7 +51,7 @@ class DonateCompleteViewController: UIViewController {
     }()
     lazy var moneyLabel: UILabel = {
         let label: UILabel = UILabel()
-        label.text = "30,000원"
+        label.text = "\(money)원"
         label.font = .spoqaHanSansNeo(ofSize: 38, weight: .bold)
         label.textColor = .white
         return label
@@ -83,6 +83,23 @@ class DonateCompleteViewController: UIViewController {
         stackView.setCustomSpacing(22, after: completeLabel)
         return stackView
     }()
+    
+    // MARK: - Properties
+    private let nickname: String
+    private let giftName: String
+    private let money: String
+    private let placeholderImage: UIImage = UIImage(named: "doneImage")!
+    
+    // MARK: - Initializer
+    init(nickname: String, giftName: String, moneyAmount: Int) {
+        self.nickname = nickname
+        self.giftName = giftName
+        self.money = moneyAmount.changeToCommaFormat() ?? "0"
+        super.init(nibName: nil, bundle: nil)
+    }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - Lifecycle
     override func viewDidLoad() {

--- a/MobalMobal/MobalMobal/DonateComplete/DonateCompleteViewController.swift
+++ b/MobalMobal/MobalMobal/DonateComplete/DonateCompleteViewController.swift
@@ -21,6 +21,7 @@ class DonateCompleteViewController: UIViewController {
         label.text = nickname
         label.font = .spoqaHanSansNeo(ofSize: 19, weight: .bold)
         label.textColor = .white
+        label.textAlignment = .right
         return label
     }()
     let zosaLabel: UILabel = {
@@ -28,6 +29,7 @@ class DonateCompleteViewController: UIViewController {
         label.text = "는"
         label.font = .spoqaHanSansNeo(ofSize: 19, weight: .regular)
         label.textColor = .white
+        label.textAlignment = .left
         return label
     }()
     lazy var giftLabel: UILabel = {
@@ -35,6 +37,8 @@ class DonateCompleteViewController: UIViewController {
         label.text = "\(giftName) 가지고 싶어요"
         label.font = .spoqaHanSansNeo(ofSize: 19, weight: .regular)
         label.textColor = .white
+        label.numberOfLines = 0
+        label.textAlignment = .center
         return label
     }()
     lazy var completeImageView: UIImageView = {
@@ -47,6 +51,7 @@ class DonateCompleteViewController: UIViewController {
         label.text = "후원완료"
         label.font = .spoqaHanSansNeo(ofSize: 22, weight: .bold)
         label.textColor = .darkCream
+        label.textAlignment = .center
         return label
     }()
     lazy var moneyLabel: UILabel = {
@@ -54,6 +59,7 @@ class DonateCompleteViewController: UIViewController {
         label.text = "\(money)원"
         label.font = .spoqaHanSansNeo(ofSize: 38, weight: .bold)
         label.textColor = .white
+        label.textAlignment = .center
         return label
     }()
     
@@ -131,7 +137,7 @@ class DonateCompleteViewController: UIViewController {
         stackView.snp.makeConstraints { make in
             make.center.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(44)
-        }        
+        }
     }
     
     @objc

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
@@ -32,9 +32,11 @@ class DonateMoneyViewController: DoneBaseViewController {
     private let cellIdentifier: String = "DonateMoneyTableViewCell"
     
     // MARK: - Initializer
-    init(postId: Int) {
+    init(postId: Int, nickname: String, giftName: String) {
         super.init(nibName: nil, bundle: nil)
         viewModel.setPostId(postId)
+        viewModel.setNickname(nickname)
+        viewModel.setGiftName(giftName)
     }
     
     required init?(coder: NSCoder) {
@@ -177,9 +179,8 @@ extension DonateMoneyViewController: DonateMoneyViewModelDelegate {
     }
     
     func completeDonateMoney(amount: Int) {
-        print("🐻 Donation Success")
         // 후원완료 페이지로 이동
-        let completeVC: DonateCompleteViewController = DonateCompleteViewController()
+        let completeVC: DonateCompleteViewController = DonateCompleteViewController(nickname: viewModel.getNickname(), giftName: viewModel.getGiftName(), moneyAmount: amount)
         completeVC.modalPresentationStyle = .fullScreen
         navigationController?.pushViewController(completeVC, animated: true)
     }

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewController.swift
@@ -118,8 +118,7 @@ extension DonateMoneyViewController: UITableViewDelegate {
         if indexPath.row < viewModel.amounts.count {
             viewModel.donate(amount: viewModel.amounts[indexPath.row])
         } else {
-            print("🐻 직접 입력 🐻")
-            let inputDonateMoneyVC: InputDonationMoneyViewController = InputDonationMoneyViewController(postId: viewModel.getPostId())
+            let inputDonateMoneyVC: InputDonationMoneyViewController = InputDonationMoneyViewController(postId: viewModel.getPostId(), nickname: viewModel.getNickname(), giftName: viewModel.getGiftName())
             inputDonateMoneyVC.modalPresentationStyle = .fullScreen
             navigationController?.pushViewController(inputDonateMoneyVC, animated: true)
         }

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewModel.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewModel.swift
@@ -67,10 +67,10 @@ class DonateMoneyViewModel {
         self.amount = amount
         
         // 잔액 부족
-//        if checkChargedPoint() < amount {
-//            delegate?.insufficientPoint()
-//            return
-//        }
+        if checkChargedPoint() < amount {
+            delegate?.insufficientPoint()
+            return
+        }
         // 정상 작동
         DoneProvider.donate(amount, to: postId) { [weak self] response in
             self?.donateData = response.data

--- a/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewModel.swift
+++ b/MobalMobal/MobalMobal/DonateMoney/DonateMoneyViewModel.swift
@@ -20,6 +20,8 @@ class DonateMoneyViewModel {
     let amounts: [Int] = [1_000, 2_000, 5_000, 10_000, 50_000, 100_000]
     
     private var postId: Int = -1
+    private var nickname: String = ""
+    private var giftName: String = ""
     private var amount: Int?
     private var donateData: DonateMoneyData? {
         didSet { donateDataChanged() }
@@ -31,11 +33,23 @@ class DonateMoneyViewModel {
     }
     
     // MARK: - getter, setter
+    func getPostId() -> Int {
+        self.postId
+    }
     func setPostId(_ postId: Int) {
         self.postId = postId
     }
-    func getPostId() -> Int {
-        self.postId
+    func getNickname() -> String {
+        self.nickname
+    }
+    func setNickname(_ nickname: String) {
+        self.nickname = nickname
+    }
+    func getGiftName() -> String {
+        self.giftName
+    }
+    func setGiftName(_ giftName: String) {
+        self.giftName = giftName
     }
     
     // MARK: - API
@@ -53,10 +67,10 @@ class DonateMoneyViewModel {
         self.amount = amount
         
         // 잔액 부족
-        if checkChargedPoint() < amount {
-            delegate?.insufficientPoint()
-            return
-        }
+//        if checkChargedPoint() < amount {
+//            delegate?.insufficientPoint()
+//            return
+//        }
         // 정상 작동
         DoneProvider.donate(amount, to: postId) { [weak self] response in
             self?.donateData = response.data

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -235,7 +235,7 @@ class DonationDetailViewController: DoneBaseViewController {
     }
     
     private func presentDonateMoneyVC() {
-        let donateMoneyVC: DonateMoneyViewController = DonateMoneyViewController(postId: viewModel.getDonationId() )
+        let donateMoneyVC: DonateMoneyViewController = DonateMoneyViewController(postId: viewModel.getDonationId(), nickname: viewModel.getNickname(), giftName: viewModel.getGiftName())
         let navigationController: UINavigationController = UINavigationController(rootViewController: donateMoneyVC)
         navigationController.modalPresentationStyle = .overFullScreen
         present(navigationController, animated: true)

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
@@ -74,6 +74,12 @@ class DonationDetailViewModel {
     func getDonationId() -> Int {
         self.donationId
     }
+    func getNickname() -> String {
+        self.donationPublisherName
+    }
+    func getGiftName() -> String {
+        self.donationTitle
+    }
     
     // MARK: - API Method
     func callDonationInfoAPI() {

--- a/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
@@ -63,9 +63,11 @@ class InputDonationMoneyViewController: DoneBaseViewController {
     private let maxMoneyRange: Int = 10_000_000
     
     // MARK: - Initializer
-    init(postId: Int) {
+    init(postId: Int, nickname: String, giftName: String) {
         super.init(nibName: nil, bundle: nil)
         viewModel.setPostId(postId)
+        viewModel.setNickname(nickname)
+        viewModel.setGiftName(giftName)
     }
     
     required init?(coder: NSCoder) {
@@ -296,7 +298,7 @@ extension InputDonationMoneyViewController: DonateMoneyViewModelDelegate {
     }
     
     func completeDonateMoney(amount: Int) {
-        print("🐻 Donation success: \(amount)원")
-        // 후원 완료 페이지로 이동
+        let completeVC: DonateCompleteViewController = DonateCompleteViewController(nickname: viewModel.getNickname(), giftName: viewModel.getGiftName(), moneyAmount: amount)
+        navigationController?.pushViewController(completeVC, animated: true)
     }
 }


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #35 

### What does this PR do?
- 도네이션 유저 닉네임, 선물 이름, 금액 반영
- label 중앙정렬, 선물 이름이 길어지면 줄바꿈
- 금액 직접 입력 페이지 -> 후원완료 페이지 링크

### Screenshots
"6번 사용자" 라고 표시되는 부분은 (#107) PR 병합되면 닉네임으로 바뀔 예정입니다.

<img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/ffcae337-9306-4059-bbf0-a96c04e3f84a/simulator_screenshot_3893F818-1E6B-4948-897A-569A38AC12F7.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210503%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210503T181251Z&X-Amz-Expires=86400&X-Amz-Signature=d057a4536aa0006a85178de5dad60d8b2820849d6c53b304cd286c2c7b0b6e24&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22simulator_screenshot_3893F818-1E6B-4948-897A-569A38AC12F7.png%22" height="600">