### PR TITLE
(#119), (#121) Main에서 내 도네이션 네트워킹, 내 도네이션 네트워킹 구조 변경해서 프로필에 적용

### DIFF
--- a/MobalMobal/MobalMobal/Main/MainViewController.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewController.swift
@@ -390,8 +390,7 @@ extension MainViewController: MainMyDonationCollectionViewCellDelegate {
         presentAddMyDonationVC()
     }
     
-    func didSelectMyOngoingDonationItem(at indexPath: IndexPath) {
-        print("🐰 나의 진행 도네이션 : \(indexPath.item)")
-        presentDonationDetailVC(donationId: indexPath.item) // viewModel.posts[indexPath.item].postID
+    func didSelectMyOngoingDonationItem(at postId: Int) {
+        presentDonationDetailVC(donationId: postId) // viewModel.posts[indexPath.item].postID
     }
 }

--- a/MobalMobal/MobalMobal/Main/MainViewModel.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewModel.swift
@@ -10,11 +10,15 @@ import Foundation
 class MainViewModel {
     // MARK: - property
     var posts: [MainPost] = []
-    var myDonations: [MydonationPost] = []
+    var myDonations: [MydonationPost] = []  //진행 중인 내 도네이션
     var limit: Int = 10
     var item: Int = Int.max
     var isEnd: Bool = false
+    weak var delegate: MainMyOngoingDonationDelegate?
     
+    var getMyDonationsCount: Int {
+        return myDonations.count
+    }
     // MARK: - API Method
     func callMainInfoApi(completion: @escaping (Result<Void, DoneError>) -> Void) {
         DoneProvider.getMain(item: item, limit: limit) { response in
@@ -43,11 +47,22 @@ class MainViewModel {
                 completion(.failure(.unknown))
                 return
             }
-            self?.myDonations = posts
+            self?.checkInprogressDonation(posts)
+            self?.delegate?.populate()
+            completion(.success(()))
         } failure: { err in
             print(err.localizedDescription)
             completion(.failure(.unknown))
         }
-
+    }
+    
+    func checkInprogressDonation(_ response: [MydonationPost]) {
+        for post in response{
+            // 날짜가 지났으면 true반환 -> expired에넣음
+            if Date().getDueDay(of: post.endAt) >= 0 {
+                self.myDonations.append(post)
+            }
+        }
+        print(self.myDonations.count, "🤨🤨🤨🤨🤨")
     }
 }

--- a/MobalMobal/MobalMobal/Main/MainViewModel.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewModel.swift
@@ -56,6 +56,7 @@ class MainViewModel {
         }
     }
     
+    // MARK: - Methods
     func checkInprogressDonation(_ response: [MydonationPost]) {
         for post in response{
             // 날짜가 지났으면 true반환 -> expired에넣음
@@ -63,6 +64,16 @@ class MainViewModel {
                 self.myDonations.append(post)
             }
         }
-        print(self.myDonations.count, "🤨🤨🤨🤨🤨")
+    }
+    func getMyDonationTitle(_ item: Int) -> String {
+        return myDonations[item].title
+    }
+    func getMyDonationMoney(_ item: Int) -> Int {
+        return myDonations[item].currentAmount
+    }
+    func getMyDonationProgress(_ item: Int) -> Float {
+        var progress: Float = 0.0
+        progress = Float(Float(( myDonations[item].currentAmount * 100 )) / Float(myDonations[item].goal))
+        return progress
     }
 }

--- a/MobalMobal/MobalMobal/Main/MainViewModel.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 class MainViewModel {
     // MARK: - property
     var posts: [MainPost] = []
-    
+    var myDonations: [MydonationPost] = []
     var limit: Int = 10
     var item: Int = Int.max
     var isEnd: Bool = false
@@ -35,5 +35,19 @@ class MainViewModel {
             print(error)
             completion(.failure(.unknown))
         }
+    }
+    
+    func callMyDonationAPI(completion: @escaping (Result<Void, DoneError>) -> Void ) {
+        DoneProvider.getMyDonation { [weak self] response in
+            guard let posts = response.data?.posts else {
+                completion(.failure(.unknown))
+                return
+            }
+            self?.myDonations = posts
+        } failure: { err in
+            print(err.localizedDescription)
+            completion(.failure(.unknown))
+        }
+
     }
 }

--- a/MobalMobal/MobalMobal/Main/cell/MainMyDonationCollectionViewCell.swift
+++ b/MobalMobal/MobalMobal/Main/cell/MainMyDonationCollectionViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol MainMyDonationCollectionViewCellDelegate: AnyObject {
     func didSelectAddMyDonationButton()
-    func didSelectMyOngoingDonationItem(at indexPath: IndexPath)
+    func didSelectMyOngoingDonationItem(at postId: Int)
 }
 
 class MainMyDonationCollectionViewCell: UICollectionViewCell {
@@ -54,7 +54,7 @@ class MainMyDonationCollectionViewCell: UICollectionViewCell {
     }
     
     // MARK: - Methods
-    private func callAPI(){
+    private func callAPI() {
         viewModel.callMyDonationAPI { result in
             switch result {
             case .success:
@@ -93,7 +93,8 @@ extension MainMyDonationCollectionViewCell: UICollectionViewDelegate {
         case 0:
             delegate?.didSelectAddMyDonationButton()
         case 1:
-            delegate?.didSelectMyOngoingDonationItem(at: indexPath)
+            let postId = viewModel.myDonations[indexPath.row].postId
+            delegate?.didSelectMyOngoingDonationItem(at: postId)
         default:
             break
         }
@@ -124,6 +125,10 @@ extension MainMyDonationCollectionViewCell: UICollectionViewDataSource {
             return cell
         default:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cardCellIdentifier, for: indexPath) as? MainMyOngoingDonationCollectionViewCell else { return .init() }
+            cell.setModel(title: viewModel.getMyDonationTitle(indexPath.item),
+                          money: viewModel.getMyDonationMoney(indexPath.item),
+                          progress: viewModel.getMyDonationProgress(indexPath.item),
+                          indexPath: indexPath.row)
             return cell
         }
     }

--- a/MobalMobal/MobalMobal/Main/cell/MainMyDonationCollectionViewCell.swift
+++ b/MobalMobal/MobalMobal/Main/cell/MainMyDonationCollectionViewCell.swift
@@ -36,14 +36,17 @@ class MainMyDonationCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Properties
     weak var delegate: MainMyDonationCollectionViewCellDelegate?
+    
     let buttonCellIdentifier: String = "MainAddMyDonationCollectionViewCell"
     let cardCellIdentifier: String = "MainMyOngoingDonationCollectionViewCell"
+    let viewModel: MainViewModel = MainViewModel()
     
     // MARK: - Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
         setCollectionView()
         setLayout()
+        callAPI()
     }
     
     required init?(coder: NSCoder) {
@@ -51,6 +54,16 @@ class MainMyDonationCollectionViewCell: UICollectionViewCell {
     }
     
     // MARK: - Methods
+    private func callAPI(){
+        viewModel.callMyDonationAPI { result in
+            switch result {
+            case .success:
+                self.collectionView.reloadData()
+            case .failure(.client), .failure(.noData), .failure(.server), .failure(.unknown):
+                print("fail")
+            }
+        }
+    }
     private func setCollectionView() {
         collectionView.delegate = self
         collectionView.dataSource = self
@@ -98,7 +111,7 @@ extension MainMyDonationCollectionViewCell: UICollectionViewDataSource {
         case 0:
             return 1
         case 1:
-            return 10
+            return viewModel.getMyDonationsCount
         default:
             return 0
         }

--- a/MobalMobal/MobalMobal/Main/cell/MainMyOngoingDonationCollectionViewCell.swift
+++ b/MobalMobal/MobalMobal/Main/cell/MainMyOngoingDonationCollectionViewCell.swift
@@ -15,7 +15,10 @@ struct MainMyDonationModel {
     let indexPathRow: Int
 }
 
-class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell {
+protocol MainMyOngoingDonationDelegate: AnyObject {
+    func populate()
+}
+class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell, MainMyOngoingDonationDelegate {
     // MARK: - UIComponents
     let cardView: UIView = {
         let view: UIView = UIView(frame: .zero)
@@ -46,6 +49,7 @@ class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell {
         return imageView
     }()
     
+    let viewModel: MainViewModel = MainViewModel()
     private var model: MainMyDonationModel {
         didSet {
             populate()
@@ -56,6 +60,7 @@ class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell {
         self.model = MainMyDonationModel(title: "default", progress: 0.0, money: 0, indexPathRow: 0)
         super.init(frame: frame)
         setLayout()
+        viewModel.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -66,7 +71,8 @@ class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell {
     func setModel(title: String, money: Int, progress: Float, indexPath: Int) {
         self.model = MainMyDonationModel(title: title, progress: progress, money: money, indexPathRow: indexPath)
     }
-    private func populate() {
+    func populate() {
+        print("🥳🥳🥳🥳 main my onging cell setting 🥳🥳🥳🥳🥳")
         donationTitleLabel.text = model.title
         donationPointLabel.text = "\(model.money)"
     }

--- a/MobalMobal/MobalMobal/Main/cell/MainMyOngoingDonationCollectionViewCell.swift
+++ b/MobalMobal/MobalMobal/Main/cell/MainMyOngoingDonationCollectionViewCell.swift
@@ -43,12 +43,21 @@ class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell, MainMyOngoi
         return label
     }()
     
-    let donationImageView: UIImageView = {
-        let imageView: UIImageView = UIImageView(image: UIImage(named: "process-01_poor-guji"))
+    lazy var donationImageView: UIImageView = {
+        let imageView: UIImageView = UIImageView(image: donateImage[0])
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
     
+    // MARK: - Properties
+    private let donateImage: [UIImage?] = [
+        UIImage(named: "process-00_yanudo"),
+        UIImage(named: "process-01_poor-guji"),
+        UIImage(named: "process-02_chicken"),
+        UIImage(named: "process-03_shopping"),
+        UIImage(named: "process-04_chanel-girl"),
+        UIImage(named: "process-05_rich")
+    ]
     let viewModel: MainViewModel = MainViewModel()
     private var model: MainMyDonationModel {
         didSet {
@@ -72,9 +81,24 @@ class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell, MainMyOngoi
         self.model = MainMyDonationModel(title: title, progress: progress, money: money, indexPathRow: indexPath)
     }
     func populate() {
-        print("🥳🥳🥳🥳 main my onging cell setting 🥳🥳🥳🥳🥳")
         donationTitleLabel.text = model.title
-        donationPointLabel.text = "\(model.money)"
+        donationPointLabel.text = model.money.changeToCommaFormat()
+        setImage()
+    }
+    private func setImage() {
+        if model.progress == 0.0 {
+            donationImageView.image = donateImage[0]
+        } else if 0.0..<25.0 ~= model.progress {
+            donationImageView.image = donateImage[1]
+        } else if 25.0..<50.0 ~= model.progress {
+            donationImageView.image = donateImage[2]
+        } else if 50.0..<75.0 ~= model.progress {
+            donationImageView.image = donateImage[3]
+        } else if 75.0..<100.0 ~= model.progress {
+            donationImageView.image = donateImage[4]
+        } else {
+            donationImageView.image = donateImage[5]
+        }
     }
     private func setLayout() {
         [cardView].forEach { contentView.addSubview($0) }

--- a/MobalMobal/MobalMobal/Main/cell/MainMyOngoingDonationCollectionViewCell.swift
+++ b/MobalMobal/MobalMobal/Main/cell/MainMyOngoingDonationCollectionViewCell.swift
@@ -8,6 +8,13 @@
 import SnapKit
 import UIKit
 
+struct MainMyDonationModel {
+    let title: String
+    let progress: Float
+    let money: Int
+    let indexPathRow: Int
+}
+
 class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell {
     // MARK: - UIComponents
     let cardView: UIView = {
@@ -39,8 +46,14 @@ class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell {
         return imageView
     }()
     
+    private var model: MainMyDonationModel {
+        didSet {
+            populate()
+        }
+    }
     // MARK: - Initializer
     override init(frame: CGRect) {
+        self.model = MainMyDonationModel(title: "default", progress: 0.0, money: 0, indexPathRow: 0)
         super.init(frame: frame)
         setLayout()
     }
@@ -50,6 +63,13 @@ class MainMyOngoingDonationCollectionViewCell: UICollectionViewCell {
     }
     
     // MARK: - Methods
+    func setModel(title: String, money: Int, progress: Float, indexPath: Int) {
+        self.model = MainMyDonationModel(title: title, progress: progress, money: money, indexPathRow: indexPath)
+    }
+    private func populate() {
+        donationTitleLabel.text = model.title
+        donationPointLabel.text = "\(model.money)"
+    }
     private func setLayout() {
         [cardView].forEach { contentView.addSubview($0) }
         

--- a/MobalMobal/MobalMobal/Profile/Cell/ProfileMyDonationTableViewCell.swift
+++ b/MobalMobal/MobalMobal/Profile/Cell/ProfileMyDonationTableViewCell.swift
@@ -93,6 +93,7 @@ class ProfileMyDonationTableViewCell: UITableViewCell {
     private let myDonationText: [String] = ["받는", "주는", "종료"]
     private lazy var myDonationNumber: [Int] = [0, 0, 0]
     let myDonationViewModel: ProfileMydonationViewModel = ProfileMydonationViewModel()
+    let viewModel: ProfileViewModel = ProfileViewModel()
     
     // MARK: - Initializer
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -142,18 +143,24 @@ class ProfileMyDonationTableViewCell: UITableViewCell {
 extension ProfileMyDonationTableViewCell: ProfileMydonationViewModelDelegate {
     func setMyDonationUI() {
         initMyDonationInfoNumber(0, 2)
-        // 내가 연 도네이션 관련 정보 처리
-        if let mydonationPosts: [MydonationPost] = myDonationViewModel.getMyDonationPosts() {
-            for post in 0..<mydonationPosts.count {
-                if myDonationViewModel.checkOutDated(postNumber: post) {
-                    myDonationNumber[2] += 1
-                } else {
-                    myDonationNumber[0] += 1
-                }
-            }
-            takeNumberOfDonation.text = "\(myDonationNumber[0])"
-            endNumberOfDonation.text = "\(myDonationNumber[2])"
-        }
+//        // 내가 연 도네이션 관련 정보 처리
+//        if let mydonationPosts: [MydonationPost] = myDonationViewModel.getMyDonationPosts() {
+//            for post in 0..<mydonationPosts.count {
+//                if myDonationViewModel.checkOutDated(postNumber: post) {
+//                    myDonationNumber[2] += 1
+//                } else {
+//                    myDonationNumber[0] += 1
+//                }
+//            }
+//            takeNumberOfDonation.text = "\(myDonationNumber[0])"
+//            endNumberOfDonation.text = "\(myDonationNumber[2])"
+//        }
+        myDonationNumber[0] = viewModel.myInprogressResponseModel.count
+        myDonationNumber[2] = viewModel.myExpiredResponseModel.count
+        print("⚠️⚠️⚠️", viewModel.myInprogressResponseModel.count)
+        print("⚠️⚠️⚠️", viewModel.myExpiredResponseModel.count)
+        takeNumberOfDonation.text = "\(myDonationNumber[0])"
+        endNumberOfDonation.text = "\(myDonationNumber[2])"
     }
     func setMyDonateUI() {
         initMyDonationInfoNumber(1)

--- a/MobalMobal/MobalMobal/Profile/Cell/ProfileMyDonationTableViewCell.swift
+++ b/MobalMobal/MobalMobal/Profile/Cell/ProfileMyDonationTableViewCell.swift
@@ -143,28 +143,14 @@ class ProfileMyDonationTableViewCell: UITableViewCell {
 extension ProfileMyDonationTableViewCell: ProfileMydonationViewModelDelegate {
     func setMyDonationUI() {
         initMyDonationInfoNumber(0, 2)
-//        // 내가 연 도네이션 관련 정보 처리
-//        if let mydonationPosts: [MydonationPost] = myDonationViewModel.getMyDonationPosts() {
-//            for post in 0..<mydonationPosts.count {
-//                if myDonationViewModel.checkOutDated(postNumber: post) {
-//                    myDonationNumber[2] += 1
-//                } else {
-//                    myDonationNumber[0] += 1
-//                }
-//            }
-//            takeNumberOfDonation.text = "\(myDonationNumber[0])"
-//            endNumberOfDonation.text = "\(myDonationNumber[2])"
-//        }
-        myDonationNumber[0] = viewModel.myInprogressResponseModel.count
-        myDonationNumber[2] = viewModel.myExpiredResponseModel.count
-        print("⚠️⚠️⚠️", viewModel.myInprogressResponseModel.count)
-        print("⚠️⚠️⚠️", viewModel.myExpiredResponseModel.count)
+        myDonationNumber[0] = myDonationViewModel.getMyInprogressModelCount() ?? 0
+        myDonationNumber[2] = myDonationViewModel.getMyExpiredModelCount() ?? 0
         takeNumberOfDonation.text = "\(myDonationNumber[0])"
         endNumberOfDonation.text = "\(myDonationNumber[2])"
     }
     func setMyDonateUI() {
         initMyDonationInfoNumber(1)
-        myDonationNumber[1] = myDonationViewModel.getMyDonatePostsNumber()
+        myDonationNumber[1] = self.myDonationViewModel.getMyDonateModelCount() ?? 0
         giveNumberOfDonation.text = "\(myDonationNumber[1])"
     }
 }

--- a/MobalMobal/MobalMobal/Profile/Cell/ProfileTableViewCell.swift
+++ b/MobalMobal/MobalMobal/Profile/Cell/ProfileTableViewCell.swift
@@ -57,7 +57,7 @@ class ProfileTableViewCell: UITableViewCell {
     // MARK: - Properties
     let cellViewModel: ProfileCellViewModel = ProfileCellViewModel()
     weak var pointChargingDelegate: pointChargingActionDelegate?
-    
+    let profileViewModel: ProfileViewModel = ProfileViewModel()
     // MARK: - Initializer
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -134,3 +134,4 @@ extension ProfileTableViewCell: ProfileCellViewModelDelegate {
         }
     }
 }
+

--- a/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
@@ -23,6 +23,7 @@ class ProfileViewController: DoneBaseViewController {
     private let sectionHeaderCellIdentifier: String = "SectionHeaderCell"
     private lazy var numberOfDonations: [Int] = [0, 0, 0]     // 내연, 후원중, 종료 갯수
     private let profileViewModel: ProfileViewModel = ProfileViewModel()
+    
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -80,12 +81,11 @@ class ProfileViewController: DoneBaseViewController {
         }
     }
     private func setNavigation() {
-
+        navigationController?.navigationBar.barStyle = .default
         self.navigationController?.navigationBar.barTintColor = .blackFour
         self.navigationController?.navigationBar.isTranslucent = false
         self.navigationController?.isNavigationBarHidden = false
         
-        self.navigationItem.title = profileViewModel.getUserNickname()
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.whiteTwo]
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "arrowChevronBigLeft"), style: .plain, target: self, action: #selector(popVC))
         
@@ -126,8 +126,6 @@ extension ProfileViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        print("🍎🍎🍎🍎", profileViewModel.myInprogressResponseModel.count)
-        print("🍎🍎🍎🍎", profileViewModel.myExpiredResponseModel.count)
         if !checkDynamicSection(section) {
             return 1
         } else {
@@ -152,7 +150,8 @@ extension ProfileViewController: UITableViewDataSource {
             guard let myDonationCell: ProfileMyDonationTableViewCell = mainTableView.dequeueReusableCell(withIdentifier: myDonationCellIdentifier, for: indexPath) as? ProfileMyDonationTableViewCell else { return UITableViewCell() }
             myDonationCell.selectionStyle = .none
             
-            myDonationCell.myDonationViewModel.setMyDonationModel(profileViewModel.mydonationResponseModel)
+            myDonationCell.myDonationViewModel.setMyInprogressModel(profileViewModel.myInprogressResponseModel)
+            myDonationCell.myDonationViewModel.setMyExpiredModel(profileViewModel.myExpiredResponseModel)
             myDonationCell.myDonationViewModel.setMyDonateModel(profileViewModel.myDonateResponseModel)
             return myDonationCell
         }
@@ -167,7 +166,6 @@ extension ProfileViewController: UITableViewDataSource {
             } else {
                 donatingCell.viewModel.setMyDonationData(profileViewModel.myExpiredResponseModel[indexPath.row])
             }
-            
             return donatingCell
         } else {        // 내가 후원한 도네
             guard let donatingCell: ProfileDonatingTableViewCell = mainTableView.dequeueReusableCell(withIdentifier: donatingCellIdentifier, for: indexPath) as? ProfileDonatingTableViewCell
@@ -218,9 +216,10 @@ extension ProfileViewController: UITableViewDelegate {
 
 // MARK: - ProfileViewModelDelegate
 extension ProfileViewController: ProfileViewModelDelegate {
-    func tableViewUpdate(section: IndexSet) {
-        self.mainTableView.reloadSections(section, with: .automatic)
-        self.navigationItem.title = profileViewModel.getUserNickname()
+    func tableViewReload() {
+        let sectionSet: IndexSet = IndexSet(0...4)
+        self.mainTableView.reloadSections(sectionSet, with: .automatic)
+        self.title = profileViewModel.getUserNickname()!
     }
 }
 

--- a/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewController/ProfileViewController.swift
@@ -126,25 +126,19 @@ extension ProfileViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        print("🍎🍎🍎🍎", profileViewModel.myInprogressResponseModel.count)
+        print("🍎🍎🍎🍎", profileViewModel.myExpiredResponseModel.count)
         if !checkDynamicSection(section) {
             return 1
         } else {
             numberOfDonations = [0, 0, 0]
-            // 내가 연 도네이션으로 -> 내연도네, 종료도네 구문
-            if let mydonationData: MydonationData = profileViewModel.mydonationResponseModel {
-                for post in 0..<mydonationData.posts.count {
-                    if profileViewModel.checkOutDated(date: mydonationData.posts[post].endAt) {
-                        numberOfDonations[2] += 1
-                    } else {
-                        numberOfDonations[0] += 1
-                    }
-                }
-            }
+            numberOfDonations[0] = profileViewModel.myInprogressResponseModel.count
             numberOfDonations[1] = profileViewModel.myDonateResponseModel.count
+            numberOfDonations[2] = profileViewModel.myExpiredResponseModel.count
             return numberOfDonations[section - 2]
         }
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
             guard let profileCell: ProfileTableViewCell = mainTableView.dequeueReusableCell(withIdentifier: profileCellIdentifier, for: indexPath) as? ProfileTableViewCell else { return UITableViewCell() }
@@ -168,9 +162,12 @@ extension ProfileViewController: UITableViewDataSource {
             else { return UITableViewCell() }
             donatingCell.selectionStyle = .none
             donatingCell.headerLabelText = sectionHeader[indexPath.section - 2]
-            if let mydonationData: MydonationData = profileViewModel.mydonationResponseModel {
-                donatingCell.viewModel.setMyDonationData(mydonationData.posts[indexPath.row])
+            if indexPath.section == 2 {
+                donatingCell.viewModel.setMyDonationData(profileViewModel.myInprogressResponseModel[indexPath.row])
+            } else {
+                donatingCell.viewModel.setMyDonationData(profileViewModel.myExpiredResponseModel[indexPath.row])
             }
+            
             return donatingCell
         } else {        // 내가 후원한 도네
             guard let donatingCell: ProfileDonatingTableViewCell = mainTableView.dequeueReusableCell(withIdentifier: donatingCellIdentifier, for: indexPath) as? ProfileDonatingTableViewCell

--- a/MobalMobal/MobalMobal/Profile/ViewModel/ProfileMydonationViewModel.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewModel/ProfileMydonationViewModel.swift
@@ -17,7 +17,12 @@ protocol ProfileMydonationViewModelDelegate: AnyObject {
 class ProfileMydonationViewModel {
     // MARK: - Properties
     weak var delegate: ProfileMydonationViewModelDelegate?
-    var myDonationModel: MydonationData? {
+    var myInprogressModel: [MydonationPost]? {
+        didSet {
+            delegate?.setMyDonationUI()
+        }
+    }
+    var myExpiredModel: [MydonationPost]? {
         didSet {
             delegate?.setMyDonationUI()
         }
@@ -30,27 +35,21 @@ class ProfileMydonationViewModel {
     func setMyDonateModel(_ model: [Donate]) {
         self.myDonateModel = model
     }
-    func setMyDonationModel(_ model: MydonationData?) {
-        self.myDonationModel = model
+    func setMyInprogressModel(_ model: [MydonationPost]) {
+        self.myInprogressModel = model
+    }
+    func setMyExpiredModel(_ model: [MydonationPost]) {
+        self.myExpiredModel = model
     }
     // postId 중복 체
-    func getMyDonatePostsNumber() -> Int {
-        var postIdSet: Set<Int> = Set<Int>()
-        guard let donates = myDonateModel else { return 0}
-        for post in donates {
-            postIdSet.insert(post.postId)
-        }
-        return postIdSet.count
+    func getMyDonateModelCount() -> Int? {
+        myDonateModel?.count
     }
-    func getMyDonationPosts() -> [MydonationPost]? {
-        myDonationModel?.posts
+    func getMyInprogressModelCount() -> Int? {
+        myInprogressModel?.count
     }
-    // 종료된도네 파악
-    // true -> 종료
-    func checkOutDated(postNumber: Int) -> Bool {
-        guard let endDate = myDonationModel?.posts[postNumber].endAt else {
-            return false
-        }
-        return Date().getDueDay(of: endDate) < 0 ? true : false
+    func getMyExpiredModelCount() -> Int? {
+        myExpiredModel?.count
     }
+    
 }

--- a/MobalMobal/MobalMobal/Profile/ViewModel/ProfileViewModel.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewModel/ProfileViewModel.swift
@@ -9,24 +9,12 @@ import Alamofire
 import Foundation
 
 protocol ProfileViewModelDelegate: AnyObject {
-    func tableViewUpdate(section: IndexSet)
+    func tableViewReload()
 }
 class ProfileViewModel {
     // MARK: - Properties
     weak var mainDelegate: ProfileViewModelDelegate?
-    var profileResponseModel: ProfileData? {
-        didSet {
-            let sectionRange: IndexSet = IndexSet(0...0)
-            mainDelegate?.tableViewUpdate(section: sectionRange)
-        }
-    }
-    // 내가 열은 도네 (종료 & 내연도네)
-    var mydonationResponseModel: MydonationData? {
-        didSet {
-            let sectionRange: IndexSet = IndexSet(1...4)
-            mainDelegate?.tableViewUpdate(section: sectionRange)
-        }
-    }
+    var profileResponseModel: ProfileData?
     var myInprogressResponseModel: [MydonationPost] = [MydonationPost]()
     var myExpiredResponseModel: [MydonationPost] = [MydonationPost]()
     var myDonateResponseModel: [Donate] = [Donate]()
@@ -63,11 +51,10 @@ class ProfileViewModel {
                 self.myDonateResponseModel.append(donate)
             }
         }
-        let sectionRange: IndexSet = IndexSet(1...4)
-        self.mainDelegate?.tableViewUpdate(section: sectionRange)
+        self.mainDelegate?.tableViewReload()
     }
     
-    //내가 열은 도네를 Inprogress와 expired로 구분
+    // 내가 연 도네를 Inprogress와 expired로 구분
     func splitModelInprogressExpired(_ response: ParseResponse<MydonationData>) {
         for post in response.data!.posts {
             // 날짜가 지났으면 true반환 -> expired에넣음
@@ -89,20 +76,15 @@ class ProfileViewModel {
     func getUserProfileImage() -> String? {
         profileResponseModel?.user.profileImage
     }
-    func getMydonation() -> MydonationData? {
-        mydonationResponseModel
-    }
-    func checkOutDated(date: Date) -> Bool {
-        // 날자가 지났으면 true반환 -> 종료된도네에 넣는다.
-        Date().getDueDay(of: date) < 0 ? true : false
-    }
     func getMyDonate() -> [Donate]? {
         myDonateResponseModel
     }
     func getPostId(section: Int, row: Int) -> Int? {
-        if section == 2 || section == 4 {
-            return mydonationResponseModel?.posts[row].postId
-        }else {
+        if section == 2 {
+            return myInprogressResponseModel[row].postId
+        } else if section == 4 {
+            return myExpiredResponseModel[row].postId
+        } else {
             return myDonateResponseModel[row].postId
         }
     }

--- a/MobalMobal/MobalMobal/Profile/ViewModel/ProfileViewModel.swift
+++ b/MobalMobal/MobalMobal/Profile/ViewModel/ProfileViewModel.swift
@@ -27,10 +27,11 @@ class ProfileViewModel {
             mainDelegate?.tableViewUpdate(section: sectionRange)
         }
     }
-    // 내가 후원한 도네
+    var myInprogressResponseModel: [MydonationPost] = [MydonationPost]()
+    var myExpiredResponseModel: [MydonationPost] = [MydonationPost]()
     var myDonateResponseModel: [Donate] = [Donate]()
     
-    // MARK: - Methods
+    // MARK: - API call
     func getProfileResponse() {
         DoneProvider.getUserProfile() { [weak self] response in
             self?.profileResponseModel = response.data
@@ -40,7 +41,7 @@ class ProfileViewModel {
     }
     func getMydontaionResponse() {
         DoneProvider.getMyDonation { [weak self] response in
-            self?.mydonationResponseModel = response.data
+            self?.splitModelInprogressExpired(response)
         } failure: { err in
             print(err.localizedDescription)
         }
@@ -52,6 +53,7 @@ class ProfileViewModel {
             print(err.localizedDescription)
         }
     }
+    
     // 후원중인도네 중복체크
     func myDonateResponseDuplicateCheck(_ response: ParseResponse<MyDonates>) {
         var donationPostId: Set<Int> = Set<Int>()
@@ -64,6 +66,20 @@ class ProfileViewModel {
         let sectionRange: IndexSet = IndexSet(1...4)
         self.mainDelegate?.tableViewUpdate(section: sectionRange)
     }
+    
+    //내가 열은 도네를 Inprogress와 expired로 구분
+    func splitModelInprogressExpired(_ response: ParseResponse<MydonationData>) {
+        for post in response.data!.posts {
+            // 날짜가 지났으면 true반환 -> expired에넣음
+            if Date().getDueDay(of: post.endAt) < 0 {
+                myExpiredResponseModel.append(post)
+            } else {
+                myInprogressResponseModel.append(post)
+            }
+        }
+    }
+    
+    // MARK: - Methods
     func getUserNickname() -> String? {
         profileResponseModel?.user.nickname
     }


### PR DESCRIPTION
### Related Issue


resolve: #119 
resolve: #121 

### What does this PR do?
- main페이지의 상단에 내가 연 도네이션(진행중이며 종료되지않은 것) 네트워킹해 보여줍니다.
- 프로필에서 보여질 내가 연 도네이션, 후원 중인 도네이션, 종료된 도네이션을 구분하는 연산과 모델구조를 변경했습니다.

### Why are we doing this?
- 기존 main에 보여지지않았던 내가 연 도네이션관련 항목이 보여지고 progress에 맞춰 이미지가 달라집니다. 상세페이지로 이동할 수 있습니다.
- 프로필에서 종료된도네이션에 종료되지않은 것이 보여지는 문제를 해결했습니다.
- 추후에 모든 flow연결하고 후원하기한 후에 progress와 관련된 이미지가 바뀌는지 테스트해볼 필요가 있을 것 같습니다!

### Screenshots
<img src="https://user-images.githubusercontent.com/42825223/116932615-76ecb780-ac9d-11eb-9410-675472f48b07.png" width=200> <img src="https://user-images.githubusercontent.com/42825223/116932621-78b67b00-ac9d-11eb-8af3-270c19ee2a73.png" width=200> <img src="https://user-images.githubusercontent.com/42825223/116932633-7b18d500-ac9d-11eb-995a-8f9879a2f86e.png" width=200>
