### PR TITLE
#128 [회원가입] Toast 추가

### DIFF
--- a/MobalMobal/MobalMobal/Setting/SettingViewController.swift
+++ b/MobalMobal/MobalMobal/Setting/SettingViewController.swift
@@ -12,6 +12,7 @@ import WebKit
 enum SettingURL: String {
     case openSource = "https://www.notion.so/iOS-Open-Source-License-0b8df2ee46f54ea684d484faf347b6b9"
     case termsAndConditioin = "https://www.notion.so/26c36382cd8448188c7532519b9019cc"
+    case privacy = "https://www.notion.so/b384c72d60cc4475af49284625f81a0e"
     case openKakaoTalk = "https://open.kakao.com/o/sRo0Df7c"
 }
 

--- a/MobalMobal/MobalMobal/Signup/SignupViewController.swift
+++ b/MobalMobal/MobalMobal/Signup/SignupViewController.swift
@@ -91,7 +91,9 @@ class SignupViewController: DoneBaseViewController {
     
     @objc
     private func termsOfServiceButtonIsTapped() {
-        print("이용약관 버튼 눌림")
+        let webViewController: WebviewController = WebviewController()
+        webViewController.webURL = SettingURL.termsAndConditioin.rawValue
+        present(webViewController, animated: true, completion: nil)
     }
     
     private let privacyButton: UIButton = {
@@ -103,7 +105,9 @@ class SignupViewController: DoneBaseViewController {
     
     @objc
     private func privacyButtonIsTapped() {
-        print("개인정보 버튼 눌림")
+        let webViewController: WebviewController = WebviewController()
+        webViewController.webURL = SettingURL.privacy.rawValue
+        present(webViewController, animated: true, completion: nil)
     }
     
     private let completeButton: UIButton = {

--- a/MobalMobal/MobalMobal/Signup/SignupViewController.swift
+++ b/MobalMobal/MobalMobal/Signup/SignupViewController.swift
@@ -8,6 +8,7 @@
 import SnapKit
 import Then
 import UIKit
+import Toast
 
 class SignupViewController: DoneBaseViewController {
     
@@ -46,16 +47,37 @@ class SignupViewController: DoneBaseViewController {
         return button
     }()
     
-    private let agreementLabel: UILabel = {
+    private let termsOfServiceLabel: UILabel = {
         let label: UILabel = UILabel()
         let underlineAttribute = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.thick.rawValue]
-        let underlineAttributedString = NSAttributedString(string: "이용약관, 개인정보 수집 및 이용", attributes: underlineAttribute)
+        let underlineAttributedString = NSAttributedString(string: "이용약관, ", attributes: underlineAttribute)
         label.attributedText = underlineAttributedString
-        let remainText: String = "에 모두 동의 합니다."
-        label.numberOfLines = 0
+        label.numberOfLines = 1
         label.font = UIFont(name: "SpoqaHanSansNeo-Bold", size: 15)
         
-        label.text = label.attributedText!.string + remainText
+        label.text = label.attributedText!.string
+        label.textColor = .white
+        return label
+    }()
+    
+    private let privacyLabel: UILabel = {
+        let label: UILabel = UILabel()
+        let underlineAttribute = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.thick.rawValue]
+        let underlineAttributedString = NSAttributedString(string: "개인정보 수집 및 이용", attributes: underlineAttribute)
+        label.attributedText = underlineAttributedString
+        label.numberOfLines = 1
+        label.font = UIFont(name: "SpoqaHanSansNeo-Bold", size: 15)
+        
+        label.text = label.attributedText!.string
+        label.textColor = .white
+        return label
+    }()
+    
+    private let descriptionLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.text = "에 모두 동의합니다."
+        label.numberOfLines = 0
+        label.font = UIFont(name: "SpoqaHanSansNeo-Bold", size: 15)
         label.textColor = .white
         return label
     }()
@@ -70,6 +92,18 @@ class SignupViewController: DoneBaseViewController {
     @objc
     private func termsOfServiceButtonIsTapped() {
         print("이용약관 버튼 눌림")
+    }
+    
+    private let privacyButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.backgroundColor = .clear
+        button.addTarget(self, action: #selector(privacyButtonIsTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    @objc
+    private func privacyButtonIsTapped() {
+        print("개인정보 버튼 눌림")
     }
     
     private let completeButton: UIButton = {
@@ -106,7 +140,6 @@ class SignupViewController: DoneBaseViewController {
         setUIViewLayout()
         addTapGestureRecognizer()
         setNavigationItems(title: "회원 가입", backButtonImageName: "arrowChevronBigLeft", action: #selector(backButtonTapped))
-                
     }
     
     @objc
@@ -191,18 +224,35 @@ class SignupViewController: DoneBaseViewController {
             make.width.equalTo(43)
         }
         
-        self.agreementView.addSubview(agreementLabel)
-        self.agreementLabel.snp.makeConstraints { make in
+        self.agreementView.addSubview(termsOfServiceLabel)
+        self.termsOfServiceLabel.snp.makeConstraints { make in
             make.centerY.equalTo(self.agreementView)
             make.leading.equalTo(self.agreementButton.snp.trailing).offset(7)
+        }
+        
+        self.agreementView.addSubview(privacyLabel)
+        self.privacyLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(self.termsOfServiceLabel)
+            make.leading.equalTo(self.termsOfServiceLabel.snp.trailing).offset(0)
+        }
+        
+        self.agreementView.addSubview(descriptionLabel)
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(self.privacyLabel)
+            make.leading.equalTo(self.privacyLabel.snp.trailing).offset(0)
             make.trailing.equalTo(self.agreementView.snp.trailing).offset(0)
         }
         
         self.agreementView.addSubview(termsOfServiceButton)
         self.termsOfServiceButton.snp.makeConstraints { make in
-            make.centerY.equalTo(self.agreementLabel)
-            make.leading.top.equalTo(self.agreementLabel)
-            make.width.equalTo(self.agreementLabel)
+            make.center.equalTo(self.termsOfServiceLabel)
+            make.width.height.equalTo(self.termsOfServiceLabel)
+        }
+        
+        self.agreementView.addSubview(privacyButton)
+        self.privacyButton.snp.makeConstraints { make in
+            make.center.equalTo(self.privacyLabel)
+            make.width.height.equalTo(self.privacyLabel)
         }
     }
     
@@ -232,10 +282,14 @@ class SignupViewController: DoneBaseViewController {
         }
     }
     
+    private func makeToast(_ message: String) {
+        self.view.makeToast(message, duration: 2.0, point: CGPoint(x: self.view.frame.width / 2, y: self.view.frame.height - 60), title: "", image: nil, completion: nil)
+    }
+    
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+    
         setup()
     }
     
@@ -257,11 +311,11 @@ extension SignupViewController {
 
 extension SignupViewController: SignUpViewModelDelegate {
     func requestNickNameAgain() {
-        print("닉네임 다시 입력하게")
+        self.makeToast("중복된 닉네임이 있습니다.")
     }
     
     func success() {
-        print("성공")
+        self.navigationController?.popViewController(animated: true)
     }
 }
 

--- a/MobalMobal/MobalMobal/Signup/ViewModel/SignupViewModel.swift
+++ b/MobalMobal/MobalMobal/Signup/ViewModel/SignupViewModel.swift
@@ -67,19 +67,16 @@ class SignupViewModel: SignupViewModelProtocol {
                 self.delegate?.requestNickNameAgain()
             } else if response.code == 200 {
                 self.delegate?.success()
-                if let token = self.loginData {
-                    self.setUserToken(loginData: token)
+                if let data = self.loginData {
+                    if KeychainManager.shared.setUserToken(data.token.token) {
+                        print("Signup Token 저장 성공")
+                    }
                 }
             }
         } failure: { (error) in
             print(error.localizedDescription)
             return
         }
-    }
-    
-    private func setUserToken(loginData: LoginData) {
-        UserDefaults.standard.setValue(loginData.token.token, forKey: UserDefaultsKeys.userToken)
-        UserInfo.shared.token = loginData.token.token
     }
     
     func apiValidation(_ nicknameTextField: UITextField, agreementButtonIsPressed: Bool) -> Bool {

--- a/MobalMobal/Podfile
+++ b/MobalMobal/Podfile
@@ -6,4 +6,5 @@ target 'MobalMobal' do
 
   pod 'SwiftLint'
   pod 'GoogleSignIn', '< 5.1'
+  pod 'Toast-Swift', '~> 5.0.1'
 end

--- a/MobalMobal/Podfile
+++ b/MobalMobal/Podfile
@@ -6,5 +6,4 @@ target 'MobalMobal' do
 
   pod 'SwiftLint'
   pod 'GoogleSignIn', '< 5.1'
-  pod 'Toast-Swift', '~> 5.0.1'
 end


### PR DESCRIPTION
### Related Issue
<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #124 

### What does this PR do?
- 회원가입 시 이미 닉네임이 존재한다면 Toast 띄우게 했습니다.
- 이전에 이용약관, 개인정보 보호 하나로 되어 있던 것 분리하고, 해당 라벨 클릭시 노션 페이지로 넘어가게 했습니다.
- signup UserDefaults로 사용하던 것 keychain으로 변경하였습니다.

### Why are we doing this?
- 일단 이메일은 영어만 되게 해놨는데 괜찮겠죠,,??
