### PR TITLE
(#143) 버그수정(도네이션 생성, 생성완료, 상세 페이지)

### DIFF
--- a/MobalMobal/MobalMobal/CreateDonation/CreateDonation.storyboard
+++ b/MobalMobal/MobalMobal/CreateDonation/CreateDonation.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4Q6-B8-uHw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4Q6-B8-uHw">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -240,7 +240,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="oaA-V3-xwV"/>
                             </scrollView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="도네이션 생성" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wKc-3m-if5">
-                                <rect key="frame" x="160.5" y="62" width="93" height="20"/>
+                                <rect key="frame" x="160.5" y="62" width="93" height="18"/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -305,6 +305,7 @@
                             <constraint firstItem="wKc-3m-if5" firstAttribute="centerX" secondItem="ubp-hp-Cf6" secondAttribute="centerX" id="irl-tc-sog"/>
                             <constraint firstItem="NYG-8C-HVe" firstAttribute="leading" secondItem="eb0-HB-4IH" secondAttribute="leading" constant="90" id="k4Y-ip-z3h"/>
                             <constraint firstItem="1Pu-cw-8Hk" firstAttribute="leading" secondItem="eb0-HB-4IH" secondAttribute="leading" id="o5i-xb-1W2"/>
+                            <constraint firstItem="1Pu-cw-8Hk" firstAttribute="top" secondItem="wKc-3m-if5" secondAttribute="bottom" constant="8" id="sJX-ol-6qX"/>
                             <constraint firstItem="L8L-NT-9oK" firstAttribute="top" secondItem="K1K-4L-BqZ" secondAttribute="top" id="vQB-ho-CnW"/>
                         </constraints>
                     </view>

--- a/MobalMobal/MobalMobal/CreateDonation/CreateDonationViewController2.swift
+++ b/MobalMobal/MobalMobal/CreateDonation/CreateDonationViewController2.swift
@@ -289,4 +289,12 @@ extension CreateDonationViewController2: CreateDonationViewModelDeleagate {
         let toastPoint: CGPoint = CGPoint(x: view.frame.midX, y: view.frame.maxY - 60)
         view.makeToast("다시 로그인 해주시기 바랍니다.", duration: 2.0, point: toastPoint, title: nil, image: nil, completion: nil)
     }
+    func inValidTypeImage() {
+        let alertController: UIAlertController = UIAlertController(title: "안내", message: "지원하지 않는 사진 타입입니다.", preferredStyle: .alert)
+        let okAction: UIAlertAction = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alertController.addAction(okAction)
+        self.present(alertController, animated: true) { [weak self] in
+            self?.photoImageView.image = nil
+        }
+    }
 }

--- a/MobalMobal/MobalMobal/CreateDonation/CreateDonationViewController2.swift
+++ b/MobalMobal/MobalMobal/CreateDonation/CreateDonationViewController2.swift
@@ -290,7 +290,7 @@ extension CreateDonationViewController2: CreateDonationViewModelDeleagate {
         view.makeToast("다시 로그인 해주시기 바랍니다.", duration: 2.0, point: toastPoint, title: nil, image: nil, completion: nil)
     }
     func inValidTypeImage() {
-        let alertController: UIAlertController = UIAlertController(title: "안내", message: "지원하지 않는 사진 타입입니다.", preferredStyle: .alert)
+        let alertController: UIAlertController = UIAlertController(title: "이미지 타입 오류", message: "지원하지 않는 이미지 타입입니다.", preferredStyle: .alert)
         let okAction: UIAlertAction = UIAlertAction(title: "확인", style: .default, handler: nil)
         alertController.addAction(okAction)
         self.present(alertController, animated: true) { [weak self] in

--- a/MobalMobal/MobalMobal/CreateDonation/ViewModel/CreateDonationViewModel.swift
+++ b/MobalMobal/MobalMobal/CreateDonation/ViewModel/CreateDonationViewModel.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol CreateDonationViewModelDeleagate: class {
     func unavaliableToken()
     func success(donationInfo: CreateDonationInfo)
+    func inValidTypeImage()
 }
 
 class CreateDonationViewModel {
@@ -34,6 +35,7 @@ class CreateDonationViewModel {
             }
         } failure: { (error) in
             print("CreateDonation : \(error.localizedDescription)")
+            self.delegate?.inValidTypeImage()
             return
         }
     }

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -322,6 +322,9 @@ extension DonationDetailViewController: DonationDetailViewModelDelegate {
     }
     func didProgressChanged(current: Int, goal: Int) {
         progress = goal == 0 ? 100.0 : Float(current) / Float(goal)
+        if progress >= 1.0 && goal == 0 {
+            progress = 1
+        }
         progressLabel.text = "\(Int(progress * 100))%"
         destinationNumberLabel.text = goal.changeToCommaFormat()
         fundAmountNumberLabel.text = current.changeToCommaFormat()

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -251,7 +251,7 @@ class DonationDetailViewController: DoneBaseViewController {
     
     // MARK: - Methods
     private func donateMySelfAlert() {
-        let alert: UIAlertController = UIAlertController(title: "안내", message: "본인의 게시물에 후원할 수 없습니다.", preferredStyle: .alert)
+        let alert: UIAlertController = UIAlertController(title: "후원 불가", message: "본인의 게시물에 후원할 수 없습니다.", preferredStyle: .alert)
         let okAction: UIAlertAction = UIAlertAction(title: "확인", style: .default, handler: nil)
         alert.addAction(okAction)
         self.present(alert, animated: true, completion: nil)

--- a/MobalMobal/MobalMobal/MakeComplete/MakeCompleteViewController.swift
+++ b/MobalMobal/MobalMobal/MakeComplete/MakeCompleteViewController.swift
@@ -66,7 +66,7 @@ class MakeCompleteViewController: UIViewController {
         let label: UILabel = UILabel()
         label.numberOfLines = 2
         if let title = donationInfo?.title {
-            label.text = "티끌모아\n\(title)"
+            label.text = "\(title)"
         }
         label.font = .spoqaHanSansNeo(ofSize: 14, weight: .medium)
         label.textColor = .white


### PR DESCRIPTION
### Related Issue


resolve: #143 

### What does this PR do?
- 도네이션 생성완료: 티끌모아 글자 제거
- 도네이션 생성: 형식에 맞지않는 이미지파일 선택하면 alert띄우기
- 도네이션 생성: 타이틀 바 하단 제약 추가
- 도네이션 상세: 목표금액이 0인 경우 후원하지않았을 때 최댓값 설정이안되어있어서 100%로 수정 (기존에는 1000%로 보였습니다)

### Why are we doing this?
- 마지막 수정이되길바랍니다.

### Screenshots