### PR TITLE
🐛 (#147) [Timezone] 생성 시, 디코딩 시 default로 두고 -> string으로 포맷팅 할 때만 KST로 설정

### DIFF
--- a/MobalMobal/MobalMobal/CreateDonation/CreateDonationViewController2.swift
+++ b/MobalMobal/MobalMobal/CreateDonation/CreateDonationViewController2.swift
@@ -157,8 +157,6 @@ class CreateDonationViewController2: UIViewController, UINavigationControllerDel
     func stringToDate(input: String) -> Date {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
         
         if let date = formatter.date(from: input) {
             return date

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -341,6 +341,7 @@ extension DonationDetailViewController: DonationDetailViewModelDelegate {
         // 종료 날짜
         let dateFormatter: DateFormatter = DateFormatter()
         dateFormatter.dateFormat = "YYYY.MM.dd"
+        dateFormatter.timeZone = TimeZone(identifier: "KST")
         endDateLabel.text = dateFormatter.string(from: date)
         
         // D-Day

--- a/MobalMobal/MobalMobal/Extension/JSONDecoder+Extension.swift
+++ b/MobalMobal/MobalMobal/Extension/JSONDecoder+Extension.swift
@@ -11,7 +11,7 @@ extension JSONDecoder.DateDecodingStrategy {
     static func iso8610WithZ() throws -> JSONDecoder.DateDecodingStrategy {
         return .custom { (decoder) -> Date in
             let formatter = DateFormatter()
-            formatter.calendar = Calendar(identifier: .iso8601)
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
             
             let container = try decoder.singleValueContainer()
             let dateStr = try container.decode(String.self)


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #147 

### What does this PR do?
- 도네 생성 시에는 타임존을 default로 두고
- 상세정보 디코딩 시에는 타임존을 utc로 두고
- string으로 포맷팅 할 때는 KST로 설정
