### PR TITLE
(#153) [회원가입] 회원가입 성공 시 바로 로그인

### DIFF
--- a/MobalMobal/MobalMobal/Main/MainViewModel.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewModel.swift
@@ -54,24 +54,36 @@ class MainViewModel {
         if let token = KeychainManager.getUserToken() {
             UserInfo.shared.token = token
             DoneProvider.getUserProfile { [weak self] response in
-                guard let user = response.data?.user else { return completion() }
+                guard let user = response.data?.user else {
+                    completion()
+                    return
+                }
                 UserInfo.shared.updateUserInfo(data: user)
                 self?.nickname = user.nickname
                 completion()
-            } failure: { _ in return completion() }
+            } failure: { _ in
+                completion()
+                return
+            }
         }
+        completion()
     }
     
     func callMainPostsApi(_ completion: @escaping () -> Void = {}) {
         DoneProvider.getMain(item: item, limit: limit) { [weak self] response in
-            guard let self = self else { return completion() }
-            
+            guard let self = self else {
+                completion()
+                return
+            }
             if response.code != 200 {
                 self.mainViewModelDelegate?.failedGetPosts(message: "진행중 데이터를 불러올 수 없습니다. \(response.message!)")
-                return completion()
+                completion()
+                return
             }
-            
-            guard let posts = response.data?.posts else { return completion() }
+            guard let posts = response.data?.posts else {
+                completion()
+                return
+            }
             if self.posts.isEmpty {
                 self.posts = posts
             } else {
@@ -86,15 +98,24 @@ class MainViewModel {
     }
     
     func callMyDonationAPI(_ completion: @escaping () -> Void = {}) {
+        if KeychainManager.isEmptyUserToken() {
+            completion()
+            return
+        }
         DoneProvider.getMyDonation(status: "IN_PROGRESS") { [weak self] response in
-            guard let self = self else { return completion() }
-            
+            guard let self = self else {
+                completion()
+                return
+            }
             if response.code != 200 {
                 self.mainViewModelDelegate?.failedGetPosts(message: "나의 진행 데이터를 불러올 수 없습니다. \(response.message!)")
-                return completion()
+                completion()
+                return
             }
-            
-            guard let posts = response.data?.posts else { return completion() }
+            guard let posts = response.data?.posts else {
+                completion()
+                return
+            }
             self.checkInprogressDonation(posts)
             completion()
         } failure: { error in
@@ -108,15 +129,15 @@ class MainViewModel {
         reset()
         callUserInfoApi {
             complete += 1
-            if complete == 3 { endRefreshing() }
+            if complete >= 3 { endRefreshing() }
         }
         callMainPostsApi {
             complete += 1
-            if complete == 3 { endRefreshing() }
+            if complete >= 3 { endRefreshing() }
         }
         callMyDonationAPI {
             complete += 1
-            if complete == 3 { endRefreshing() }
+            if complete >= 3 { endRefreshing() }
         }
         
         UserInfo.shared.needToUpdate = false

--- a/MobalMobal/MobalMobal/MakeComplete/MakeCompleteViewController.swift
+++ b/MobalMobal/MobalMobal/MakeComplete/MakeCompleteViewController.swift
@@ -28,6 +28,7 @@ class MakeCompleteViewController: UIViewController {
         label.numberOfLines = 3
         label.font = .spoqaHanSansNeo(ofSize: 36, weight: .medium)
         label.textColor = .white
+        label.textAlignment = .center
         return label
     }()
     let completeLabel: UILabel = {
@@ -35,6 +36,7 @@ class MakeCompleteViewController: UIViewController {
         label.text = "생성완료"
         label.font = .spoqaHanSansNeo(ofSize: 36, weight: .regular)
         label.textColor = .veryLightPink
+        label.textAlignment = .center
         return label
     }()
     lazy var donationImageView: UIImageView = {

--- a/MobalMobal/MobalMobal/Signup/SignupViewController.swift
+++ b/MobalMobal/MobalMobal/Signup/SignupViewController.swift
@@ -333,7 +333,7 @@ extension SignupViewController: SignUpViewModelDelegate {
     }
     
     func success() {
-        self.navigationController?.popViewController(animated: true)
+        self.navigationController?.dismiss(animated: true)
     }
 }
 

--- a/MobalMobal/MobalMobal/Signup/ViewModel/SignupViewModel.swift
+++ b/MobalMobal/MobalMobal/Signup/ViewModel/SignupViewModel.swift
@@ -69,6 +69,7 @@ class SignupViewModel: SignupViewModelProtocol {
                 self.delegate?.success()
                 if let data = self.loginData {
                     if KeychainManager.setUserToken(data.token.token) {
+                        UserInfo.shared.needToUpdate = true
                         print("Signup Token 저장 성공")
                     }
                 }


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #153 

### What does this PR do?
- 회원가입 성공 시
  - 키체인에 토큰 저장
  - dismiss하여 메인으로 돌아감
  - refresh 하여 바로 유저정보 받아옴

+) 추가로 게스트로 로그인하였을 때 새로고침 시 토큰이 없어 Toast 메세지 뜨는 부분과, 무한 인디케이터가 돌아가는 부분을 수정하였습니다.
+) 도네 생성 완료페이지의 giftLabel textAlignment를 center 로 수정하였습니다.