### PR TITLE
🐛 [메인화면] post가 0개일 때는 cell이 보이지 않도록 함

### DIFF
--- a/MobalMobal/MobalMobal/Main/MainViewController.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewController.swift
@@ -286,6 +286,7 @@ extension MainViewController: UICollectionViewDataSource {
             if viewModel.isEnd {
                 return viewModel.posts.count
             }
+            if viewModel.posts.count == 0 { return 0 }
             return viewModel.posts.count + 1
         default:
             return 0


### PR DESCRIPTION
### What does this PR do?
- 메인화면에서 indicator 셀 때문에, dataSource에서 posts.count + 1 개를 보여주고 있었습니다.
- post가 없으면, indicator 셀도 보여질 필요가 없으므로, 이 부분을 수정하였습니다.