### PR TITLE
⚡️(#169) : network error reload 기능 추가

### DIFF
--- a/MobalMobal/MobalMobal/CreateDonation/ViewModel/CreateDonationViewModel.swift
+++ b/MobalMobal/MobalMobal/CreateDonation/ViewModel/CreateDonationViewModel.swift
@@ -35,6 +35,7 @@ class CreateDonationViewModel {
             }
         } failure: { (error) in
             print("CreateDonation : \(error.localizedDescription)")
+            // 현재 이미지 타입 에러에 대한 API 처리가 안되어 있음
             self.delegate?.inValidTypeImage()
             return
         }

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewController.swift
@@ -369,4 +369,10 @@ extension DonationDetailViewController: DonationDetailViewModelDelegate {
             dDayLabel.text = "D+\(-dueDay)"
         }
     }
+    
+    func networkError() {
+        self.presentNetworkViewController { [weak self] in
+            self?.viewModel.callDonationInfoAPI()
+        }
+    }
 }

--- a/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
+++ b/MobalMobal/MobalMobal/DonationDetail/DonationDetailViewModel.swift
@@ -15,6 +15,7 @@ protocol DonationDetailViewModelDelegate: class {
     func didDesciptionChanged(to description: String)
     func didProgressChanged(current: Int, goal: Int)
     func didEndDateChanged(to date: Date?)
+    func networkError()
 }
 
 class DonationDetailViewModel {
@@ -93,7 +94,8 @@ class DonationDetailViewModel {
     func callDonationInfoAPI() {
         DoneProvider.getDonationDetail(postId: donationId) { [weak self] response in
             self?.detailResponse = response.data
-        } failure: { _ in
+        } failure: { [weak self] _ in
+            self?.delegate?.networkError()
             return
         }
     }

--- a/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
+++ b/MobalMobal/MobalMobal/Extension/UIViewController+Extension.swift
@@ -29,4 +29,11 @@ extension UIViewController {
         let toastPoint: CGPoint = CGPoint(x: view.frame.midX, y: view.frame.maxY - 60)
         view.makeToast(message, duration: 2.0, point: toastPoint, title: nil, image: nil, completion: nil)
     }
+    
+    func presentNetworkViewController(reload: @escaping () -> Void) {
+        let viewController: NetworkErrorViewController = NetworkErrorViewController()
+        viewController.reload = reload
+        viewController.modalPresentationStyle = .fullScreen
+        present(viewController, animated: true, completion: nil)
+    }
 }

--- a/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
+++ b/MobalMobal/MobalMobal/InputDonationMoney/InputDonationMoneyViewController.swift
@@ -63,6 +63,7 @@ class InputDonationMoneyViewController: DoneBaseViewController {
     private let buttonString: String = "후원하기"
     private let maxMoneyRange: Int = 10_000_000
     private var isUpdateConstraints: Bool = false
+    private var intAmount: Int = 0
     
     // MARK: - Initializer
     init(postId: Int, nickname: String, giftName: String) {
@@ -115,11 +116,12 @@ class InputDonationMoneyViewController: DoneBaseViewController {
     // MARK: - Actions
     @objc
     private func clickDonationButton() {
-        guard let intAmount = Int(makeRawString(from: textField.text)) else {
+        guard let inputAmount = Int(makeRawString(from: textField.text)) else {
             print("🐻 잘못된 입력값 \(textField.text!)")
             return
         }
-        viewModel.donate(amount: intAmount)
+        self.intAmount = inputAmount
+        viewModel.donate(amount: self.intAmount)
     }
     @objc
     private func clickNavigationBackButton() {
@@ -203,6 +205,14 @@ class InputDonationMoneyViewController: DoneBaseViewController {
         let alert: UIAlertController = UIAlertController(title: "후원 실패", message: "에러가 발생했습니다. 잠시 후 다시 시도해주세요.", preferredStyle: .alert)
         let okAction: UIAlertAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             self?.navigationController?.dismiss(animated: true)
+        }
+        
+        let tryAgainAction: UIAlertAction = UIAlertAction(title: "다시 시도", style: .default) { [weak self] _ in
+            self?.presentNetworkViewController(reload: { [weak self] in
+                if let inputAmount = self?.intAmount {
+                    self?.viewModel.donate(amount: inputAmount)
+                }
+            })
         }
         alert.addAction(okAction)
         present(alert, animated: true)

--- a/MobalMobal/MobalMobal/Login/LoginViewController.swift
+++ b/MobalMobal/MobalMobal/Login/LoginViewController.swift
@@ -160,6 +160,12 @@ class LoginViewController: DoneBaseViewController {
         let signUpVC: SignupViewController = SignupViewController()
         navigationController?.pushViewController(signUpVC, animated: true)
     }
+    
+    private func presentNetworkErrorController() {
+        self.presentNetworkViewController { [weak self] in
+            self?.viewModel.callUserAPI()
+        }
+    }
 }
 
 // MARK: - LoginViewModelDelegate
@@ -171,4 +177,9 @@ extension LoginViewController: LoginViewModelDelegate {
     func needToSignUp() {
         pushSignUpViewController()
     }
+    
+    func networkError() {
+        presentNetworkErrorController()
+    }
+    
 }

--- a/MobalMobal/MobalMobal/Login/ViewModel/LoginViewModel.swift
+++ b/MobalMobal/MobalMobal/Login/ViewModel/LoginViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol LoginViewModelDelegate: AnyObject {
     func needToSignUp()
     func successLogin()
+    func networkError()
 }
 
 class LoginViewModel {
@@ -43,7 +44,7 @@ class LoginViewModel {
         } failure: { _ in return }
     }
     
-    private func callUserAPI() {
+    func callUserAPI() {
         DoneProvider.getUserProfile { [weak self]  response in
             self?.userData = response.data?.user
             if response.code == 200 {
@@ -53,7 +54,9 @@ class LoginViewModel {
             }
             guard let message = response.message else { return }
             print("🐻 유저 정보를 불러오는데 실패했습니다. : \(message)")
-        } failure: { _ in return }
+        } failure: { [weak self] _ in
+            self?.delegate?.networkError()
+        }
     }
     
     private func fireStoreIdChanged() {

--- a/MobalMobal/MobalMobal/Main/MainViewModel.swift
+++ b/MobalMobal/MobalMobal/Main/MainViewModel.swift
@@ -95,7 +95,7 @@ class MainViewModel {
             }
             completion()
         } failure: { error in
-            self.mainViewModelDelegate?.failedGetPosts(message: "진행중 데이터를 불러올 수 없습니다. \(error.localizedDescription)")
+            self.mainViewModelDelegate?.failedGetPosts(message: "진행중 데이터를 불러올 수 없습니다.")
             completion()
         }
     }
@@ -122,7 +122,7 @@ class MainViewModel {
             self.myDonations += posts
             completion()
         } failure: { error in
-            self.mainViewModelDelegate?.failedGetPosts(message: "나의 진행 데이터를 불러올 수 없습니다. \(error.localizedDescription)")
+            self.mainViewModelDelegate?.failedGetPosts(message: "나의 진행 데이터를 불러올 수 없습니다.")
             completion()
         }
         DoneProvider.getMyDonation(status: "BEFORE") { [weak self] response in
@@ -135,7 +135,7 @@ class MainViewModel {
             guard let posts = response.data?.posts else { return }
             self.myDonations += posts
         } failure: { error in
-            self.mainViewModelDelegate?.failedGetPosts(message: "나의 진행 데이터를 불러올 수 없습니다. \(error.localizedDescription)")
+            self.mainViewModelDelegate?.failedGetPosts(message: "나의 진행 데이터를 불러올 수 없습니다.")
         }
 
     }

--- a/MobalMobal/MobalMobal/Network/NetworkErrorViewController.swift
+++ b/MobalMobal/MobalMobal/Network/NetworkErrorViewController.swift
@@ -52,6 +52,9 @@ class NetworkErrorViewController: UIViewController {
             
         return button
     }()
+    
+    // MARK: - Property
+    var reload: (() -> Void)?
 
     // MARK: - Method
     private func setup() {
@@ -66,7 +69,9 @@ class NetworkErrorViewController: UIViewController {
     
     @objc
     private func retryButtonIsTapped() {
-        print("다시시도 버튼 눌림")
+        self.dismiss(animated: true) { [weak self] in
+            self?.reload?()
+        }
     }
     
     private func setLayout() {

--- a/MobalMobal/MobalMobal/Network/NetworkErrorViewController.swift
+++ b/MobalMobal/MobalMobal/Network/NetworkErrorViewController.swift
@@ -68,9 +68,9 @@ class NetworkErrorViewController: UIViewController {
     }
     
     @objc
-    private func retryButtonIsTapped() {
-        self.dismiss(animated: true) { [weak self] in
-            self?.reload?()
+    private func retryButtonIsTapped() {        
+        self.dismiss(animated: true) {
+            self.reload?()
         }
     }
     

--- a/MobalMobal/MobalMobal/Signup/SignupViewController.swift
+++ b/MobalMobal/MobalMobal/Signup/SignupViewController.swift
@@ -363,6 +363,14 @@ extension SignupViewController: SignUpViewModelDelegate {
     func success() {
         self.navigationController?.dismiss(animated: true)
     }
+    
+    func networkError() {
+        self.presentNetworkViewController { [weak self] in
+            if let user = self?.signupUser {
+                self?.signupViewModel.signup(signupUser: user)
+            }
+        }
+    }
 }
 
 extension SignupViewController: UITextFieldDelegate {

--- a/MobalMobal/MobalMobal/Signup/ViewModel/SignupViewModel.swift
+++ b/MobalMobal/MobalMobal/Signup/ViewModel/SignupViewModel.swift
@@ -19,6 +19,7 @@ protocol SignupViewModelProtocol {
 protocol SignUpViewModelDelegate: class {
     func requestNickNameAgain()
     func success()
+    func networkError()
 }
 
 class SignupViewModel: SignupViewModelProtocol {


### PR DESCRIPTION
### Related Issue

<!-- 
Use 'resolve' when you have completed the issue and want to close it. -->
resolve: #169 

### What does this PR do?
- NetworkErrorViewController에 reload 클로저 추가했습니다.
- 현재 다시시도 버튼 누르면 reload 전달하고 네트워크 에러 페이지 dismiss 됩니다. 
- 일단은 에러 처리 되어 있지 않은 곳에 추가하였습니다. 
- 그리고 에러처리 하다 보니 Toast 메세지에 localizedDescription도 같이 나오도록 되어 있는데, 이 부분까지 보여줄 필요 없다고 생각해서 일단은 제거하였습니다!
