### PR TITLE
내 계좌 정보 patch

### DIFF
--- a/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
+++ b/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		7C36DF4625F2014E001C2DBB /* InputChargingPointViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C36DF4525F2014E001C2DBB /* InputChargingPointViewController.swift */; };
 		7C39979125F75B5900EA82C2 /* SuccessChargingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C39979025F75B5900EA82C2 /* SuccessChargingViewController.swift */; };
 		7C39985D25FA51AA00EA82C2 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C39985C25FA51AA00EA82C2 /* AccountViewController.swift */; };
+		7C4B1A53266DF558001DA144 /* MyAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B1A52266DF558001DA144 /* MyAccountViewModel.swift */; };
+		7C4B1A55266DF74D001DA144 /* MyAccountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B1A54266DF74D001DA144 /* MyAccountModel.swift */; };
 		7C61AEC925EA4CC200D9149F /* PointChargingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61AEC825EA4CC200D9149F /* PointChargingViewController.swift */; };
 		7C61AED225EA4FA300D9149F /* PointChargingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61AED125EA4FA300D9149F /* PointChargingTableViewCell.swift */; };
 		7C842FA02606267400A66756 /* ModifyProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C842F9F2606267400A66756 /* ModifyProfileViewController.swift */; };
@@ -183,6 +185,8 @@
 		7C36DF4525F2014E001C2DBB /* InputChargingPointViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputChargingPointViewController.swift; sourceTree = "<group>"; };
 		7C39979025F75B5900EA82C2 /* SuccessChargingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessChargingViewController.swift; sourceTree = "<group>"; };
 		7C39985C25FA51AA00EA82C2 /* AccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewController.swift; sourceTree = "<group>"; };
+		7C4B1A52266DF558001DA144 /* MyAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountViewModel.swift; sourceTree = "<group>"; };
+		7C4B1A54266DF74D001DA144 /* MyAccountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountModel.swift; sourceTree = "<group>"; };
 		7C61AEC825EA4CC200D9149F /* PointChargingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointChargingViewController.swift; sourceTree = "<group>"; };
 		7C61AED125EA4FA300D9149F /* PointChargingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointChargingTableViewCell.swift; sourceTree = "<group>"; };
 		7C842F9F2606267400A66756 /* ModifyProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyProfileViewController.swift; sourceTree = "<group>"; };
@@ -682,6 +686,8 @@
 				E3F1EA8325EA552800F34BDE /* SettingViewController.swift */,
 				7C062D9E2621111000F5D58D /* WebviewController.swift */,
 				7CE63717263C5D32008AE55E /* MyAccountViewController.swift */,
+				7C4B1A52266DF558001DA144 /* MyAccountViewModel.swift */,
+				7C4B1A54266DF74D001DA144 /* MyAccountModel.swift */,
 			);
 			path = Setting;
 			sourceTree = "<group>";
@@ -898,10 +904,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7C4B1A55266DF74D001DA144 /* MyAccountModel.swift in Sources */,
 				D7AC0C9525EAB9E2000A342A /* MainMyDonationCollectionViewCell.swift in Sources */,
 				D7AC0C9925EACAC8000A342A /* MainAddMyDonationCollectionViewCell.swift in Sources */,
 				3A6CFF3325EAEC7A00214E43 /* CustomLoginButton.swift in Sources */,
 				4DBDB4F5261F59A500B5E08D /* DoneProvider.swift in Sources */,
+				7C4B1A53266DF558001DA144 /* MyAccountViewModel.swift in Sources */,
 				E365FBBD26210B480036617A /* CreateDonationViewController2.swift in Sources */,
 				3AC39404261DBDF5008BB207 /* DonationDetailResponse.swift in Sources */,
 				4DBDB4F8261F614F00B5E08D /* NetworkProvider.swift in Sources */,

--- a/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
+++ b/MobalMobal/MobalMobal.xcodeproj/project.pbxproj
@@ -68,7 +68,6 @@
 		7C39979125F75B5900EA82C2 /* SuccessChargingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C39979025F75B5900EA82C2 /* SuccessChargingViewController.swift */; };
 		7C39985D25FA51AA00EA82C2 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C39985C25FA51AA00EA82C2 /* AccountViewController.swift */; };
 		7C4B1A53266DF558001DA144 /* MyAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B1A52266DF558001DA144 /* MyAccountViewModel.swift */; };
-		7C4B1A55266DF74D001DA144 /* MyAccountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B1A54266DF74D001DA144 /* MyAccountModel.swift */; };
 		7C61AEC925EA4CC200D9149F /* PointChargingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61AEC825EA4CC200D9149F /* PointChargingViewController.swift */; };
 		7C61AED225EA4FA300D9149F /* PointChargingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C61AED125EA4FA300D9149F /* PointChargingTableViewCell.swift */; };
 		7C842FA02606267400A66756 /* ModifyProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C842F9F2606267400A66756 /* ModifyProfileViewController.swift */; };
@@ -186,7 +185,6 @@
 		7C39979025F75B5900EA82C2 /* SuccessChargingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessChargingViewController.swift; sourceTree = "<group>"; };
 		7C39985C25FA51AA00EA82C2 /* AccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewController.swift; sourceTree = "<group>"; };
 		7C4B1A52266DF558001DA144 /* MyAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountViewModel.swift; sourceTree = "<group>"; };
-		7C4B1A54266DF74D001DA144 /* MyAccountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountModel.swift; sourceTree = "<group>"; };
 		7C61AEC825EA4CC200D9149F /* PointChargingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointChargingViewController.swift; sourceTree = "<group>"; };
 		7C61AED125EA4FA300D9149F /* PointChargingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointChargingTableViewCell.swift; sourceTree = "<group>"; };
 		7C842F9F2606267400A66756 /* ModifyProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyProfileViewController.swift; sourceTree = "<group>"; };
@@ -687,7 +685,6 @@
 				7C062D9E2621111000F5D58D /* WebviewController.swift */,
 				7CE63717263C5D32008AE55E /* MyAccountViewController.swift */,
 				7C4B1A52266DF558001DA144 /* MyAccountViewModel.swift */,
-				7C4B1A54266DF74D001DA144 /* MyAccountModel.swift */,
 			);
 			path = Setting;
 			sourceTree = "<group>";
@@ -904,7 +901,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7C4B1A55266DF74D001DA144 /* MyAccountModel.swift in Sources */,
 				D7AC0C9525EAB9E2000A342A /* MainMyDonationCollectionViewCell.swift in Sources */,
 				D7AC0C9925EACAC8000A342A /* MainAddMyDonationCollectionViewCell.swift in Sources */,
 				3A6CFF3325EAEC7A00214E43 /* CustomLoginButton.swift in Sources */,

--- a/MobalMobal/MobalMobal/Network/DoneProvider.swift
+++ b/MobalMobal/MobalMobal/Network/DoneProvider.swift
@@ -44,4 +44,8 @@ enum DoneProvider {
     static func charge(amount: Int, userName: String, chargedAt: String, success: @escaping (ParseResponse<ChargingData>) -> Void, failure: @escaping (Error) -> Void) {
         NetworkProvider.request(.charge(amount: amount, userName: userName, chargedAt: chargedAt), to: ChargingData.self, success: success, failure: failure)
     }
+    
+    static func myAccount(bankName: String?, accountNumber: String?, success: @escaping (ParseResponse<ProfileData>) -> Void, failure: @escaping (Error) -> Void) {
+        NetworkProvider.request(.myAccount(accountNumber: accountNumber, bankName: bankName), to: ProfileData.self, success: success, failure: failure)
+    }
 }

--- a/MobalMobal/MobalMobal/Network/DoneService.swift
+++ b/MobalMobal/MobalMobal/Network/DoneService.swift
@@ -19,6 +19,7 @@ enum DoneService {
     case getMyDonation(status: String)
     case getMyDonate
     case charge(amount: Int, userName: String, chargedAt: String)
+    case myAccount(accountNumber: String?, bankName: String?)
 }
 
 extension DoneService: TargetType {
@@ -52,6 +53,8 @@ extension DoneService: TargetType {
             return "/charge"
         case .createDonation:
             return "/posts"
+        case .myAccount:
+            return "/users"
         }
     }
     
@@ -62,6 +65,8 @@ extension DoneService: TargetType {
 
         case .login, .donate, .charge, .createDonation, .signup:
             return .post
+        case .myAccount:
+            return .patch
         }
     }
     
@@ -106,6 +111,10 @@ extension DoneService: TargetType {
             return .uploadMultipart(multipartData)
         case .getMyDonation(let status):
             return .requestParameters(parameters: ["status": status], encoding: URLEncoding.queryString)
+        case .myAccount(let bankName, let accountNumber):
+            return .requestCompositeParameters(bodyParameters: ["next_user": [ "account_number": accountNumber,
+                                                                               "bank_name": bankName
+            ]], bodyEncoding: JSONEncoding.default, urlParameters: [:])
         }
     }
         
@@ -113,7 +122,7 @@ extension DoneService: TargetType {
         switch self {
         case .login, .signup:
             return nil
-        case .getMain, .getDetail, .donate, .getUserProfile, .getMyDonate, .getMyDonation, .charge, .createDonation:
+        case .getMain, .getDetail, .donate, .getUserProfile, .getMyDonate, .getMyDonation, .charge, .createDonation, .myAccount:
             guard let token = KeychainManager.getUserToken() else {
                 print("🐻 [Login Required] keychain token nil")
                 return nil

--- a/MobalMobal/MobalMobal/Setting/MyAccountModel.swift
+++ b/MobalMobal/MobalMobal/Setting/MyAccountModel.swift
@@ -1,0 +1,9 @@
+//
+//  MyAccountModel.swift
+//  MobalMobal
+//
+//  Created by 송서영 on 2021/06/07.
+//
+
+import Foundation
+

--- a/MobalMobal/MobalMobal/Setting/MyAccountModel.swift
+++ b/MobalMobal/MobalMobal/Setting/MyAccountModel.swift
@@ -1,9 +1,0 @@
-//
-//  MyAccountModel.swift
-//  MobalMobal
-//
-//  Created by 송서영 on 2021/06/07.
-//
-
-import Foundation
-

--- a/MobalMobal/MobalMobal/Setting/MyAccountViewController.swift
+++ b/MobalMobal/MobalMobal/Setting/MyAccountViewController.swift
@@ -67,6 +67,9 @@ class MyAccountViewController: UIViewController {
         return button
     }()
     
+    // MARK: - Properties
+    private let myAccountViewModel: MyAccountViewModel = MyAccountViewModel()
+    
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -75,6 +78,8 @@ class MyAccountViewController: UIViewController {
         viewTapGesture()
         setNavigationItems()
         setLayout()
+        initAPICall()
+        myAccountViewModel.delegate = self
     }
     
     // MARK: - Actions
@@ -90,10 +95,10 @@ class MyAccountViewController: UIViewController {
     }
     @objc
     private func saveBtnAction() {
-        // TODO
-        // 네트워크 통신 필요
+        myAccountViewModel.bankName = bankNameInputTextField.text
+        myAccountViewModel.accountName = accountNumberInputTextField.text
+        myAccountViewModel.patchMyAccount()
         self.navigationController?.popViewController(animated: true)
-        print("🥳 my account save btn action")
     }
     @objc
     private func popVC() {
@@ -101,6 +106,18 @@ class MyAccountViewController: UIViewController {
     }
     
     // MARK: - Methods
+    private func initAPICall() {
+        myAccountViewModel.getMyProfile { [weak self] success in
+            if success {
+                if let bankName = self?.myAccountViewModel.getBankName,
+                   let accountNumber = self?.myAccountViewModel.getAccountName {
+                    self?.bankNameInputTextField.text = bankName
+                    self?.accountNumberInputTextField.text = accountNumber
+                    self?.activateButtonUI()
+                }
+            }
+        }
+    }
     private func viewTapGesture() {
         let tapGestureRecognizer: UITapGestureRecognizer = UITapGestureRecognizer()
         tapGestureRecognizer.delegate = self
@@ -165,5 +182,15 @@ extension MyAccountViewController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         self.view.endEditing(true)
         return true
+    }
+}
+
+// MARK: - MyAccountViewModelDelegate
+extension MyAccountViewController: MyAccountViewModelDeleagte {
+    func networkErr() {
+        let netWorkVC: NetworkErrorViewController = NetworkErrorViewController()
+        self.present(netWorkVC, animated: true) { [weak self] in
+            self?.myAccountViewModel.patchMyAccount()
+        }
     }
 }

--- a/MobalMobal/MobalMobal/Setting/MyAccountViewModel.swift
+++ b/MobalMobal/MobalMobal/Setting/MyAccountViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  MyAccountViewModel.swift
+//  MobalMobal
+//
+//  Created by 송서영 on 2021/06/07.
+//
+
+import UIKit
+
+protocol MyAccountViewModelDeleagte: NSObject {
+    func networkErr()
+}
+
+class MyAccountViewModel {
+    
+    // MARK: - Properties
+    var model: ProfileData?
+    var bankName: String?
+    var accountName: String?
+    weak var delegate: MyAccountViewModelDeleagte?
+    var getBankName: String? {
+        model?.user.bankName
+    }
+    var getAccountName: String? {
+        model?.user.accountNumber
+    }
+    
+    // MARK: -API call
+    func patchMyAccount() {
+        DoneProvider.myAccount(bankName: bankName, accountNumber: accountName) { [weak self] response in
+            self?.model = response.data
+        } failure: { [weak self] err in
+            print("path my account error: ", err.localizedDescription)
+            self?.delegate?.networkErr()
+        }
+        
+    }
+    func getMyProfile(_ completion: @escaping (Bool) -> Void) {
+        DoneProvider.getUserProfile() { [weak self] response in
+            if let _ = response.data?.user.accountNumber,
+               let _ = response.data?.user.bankName {
+                self?.model = response.data
+                return completion(true)
+            }
+        } failure: { [weak self] err in
+            print("get my profile error: ",err.localizedDescription)
+            self?.delegate?.networkErr()
+        }
+    }
+
+}

--- a/MobalMobal/MobalMobal/Setting/SettingViewController.swift
+++ b/MobalMobal/MobalMobal/Setting/SettingViewController.swift
@@ -18,7 +18,7 @@ enum SettingURL: String {
 
 class SettingViewController: DoneBaseViewController {
     // MARK: - UIView
-    /* 1차배포 제외대상
+
     private let myAccountLabel: UILabel = {
         let label: UILabel = UILabel()
         label.font = .spoqaHanSansNeo(ofSize: 15, weight: .regular)
@@ -31,7 +31,7 @@ class SettingViewController: DoneBaseViewController {
         button.addTarget(self, action: #selector(myAccountAction), for: .touchUpInside)
         return button
     }()
- */
+
     private let openSourceLabel: UILabel = {
         let label: UILabel = UILabel()
         label.font = .spoqaHanSansNeo(ofSize: 15, weight: .regular)
@@ -136,8 +136,8 @@ class SettingViewController: DoneBaseViewController {
     private func setup() {
         self.view.backgroundColor = .backgroundColor
         self.setNavigationController()
-        self.view.addSubviews([openSourceLabel, termsAndConditionLabel, inquiryLabel, logoutLabel])
-        self.view.addSubviews([openSourceButton, termsAndConditionButton, inquiryButton, logoutButton])
+        self.view.addSubviews([myAccountLabel, openSourceLabel, termsAndConditionLabel, inquiryLabel, logoutLabel])
+        self.view.addSubviews([myAccountButton, openSourceButton, termsAndConditionButton, inquiryButton, logoutButton])
         self.setConstraint()
     }
     
@@ -158,19 +158,19 @@ class SettingViewController: DoneBaseViewController {
     }
     
     private func setConstraint() {
-        /* 1차배포 제외대상
+
         myAccountLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(28)
-            make.leading.equalToSuperview().offset(21)
+            make.leading.trailing.equalToSuperview().inset(21)
         }
         myAccountButton.snp.makeConstraints { make in
             make.top.bottom.equalTo(myAccountLabel)
             make.leading.trailing.equalToSuperview().inset(21)
         }
- */
+
         openSourceLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(28)
-            make.leading.equalToSuperview().offset(21)
+            make.top.equalTo(myAccountLabel.snp.bottom).offset(31)
+            make.leading.trailing.equalTo(myAccountLabel)
         }
         openSourceButton.snp.makeConstraints { make in
             make.top.bottom.equalTo(openSourceLabel)
@@ -197,7 +197,7 @@ class SettingViewController: DoneBaseViewController {
 //
         inquiryLabel.snp.makeConstraints { make in
             make.top.equalTo(termsAndConditionLabel.snp.bottom).offset(31)
-            make.leading.equalTo(termsAndConditionLabel)
+            make.leading.trailing.equalTo(termsAndConditionLabel)
         }
         inquiryButton.snp.makeConstraints { make in
             make.top.bottom.equalTo(inquiryLabel)
@@ -206,7 +206,7 @@ class SettingViewController: DoneBaseViewController {
         
         logoutLabel.snp.makeConstraints { make in
             make.top.equalTo(inquiryButton.snp.bottom).offset(31)
-            make.leading.equalTo(inquiryLabel)
+            make.leading.trailing.equalTo(inquiryLabel)
         }
         logoutButton.snp.makeConstraints { make in
             make.top.bottom.equalTo(logoutLabel)


### PR DESCRIPTION
### Related Issue

resolve: #113 

### What does this PR do?
- 내 계좌 정보를 받아오고 보냅니다. 
- (받아와서 보여주는 UI가 따로 없는 것 같아 옵셔널이 아니라면 textField에 바로 보여주도록 구현했습니다)

### Why are we doing this?
- 꼭 필요한 기능입니다.

### Screenshots

|유저의 계좌정보가 없을 때| 유저의 계좌정보가 있을 때|
|-------------|----------------|
|<img src="https://user-images.githubusercontent.com/42825223/120977500-5b019780-c7ae-11eb-8f20-95c1835fc84c.png" width=200>|<img src="https://user-images.githubusercontent.com/42825223/120977504-5ccb5b00-c7ae-11eb-979d-7df62c54468b.png" width =200> |
